### PR TITLE
Add simple git author harvester

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ haggis = "hermes.cli:haggis"
 
 [tool.poetry.plugins."hermes.harvest"]
 cff = "hermes.commands.harvest.cff:harvest_cff"
+git = "hermes.commands.harvest.git:harvest_git"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -16,22 +16,24 @@ from hermes.model.errors import HermesValidationError
 # TODO: can and should we get this somehow?
 SHELL_ENCODING = 'utf-8'
 
+
 class ConributorData:
     def __init__(self, d: t.List):
         self.name = d[0]
         self.email = set((d[1],))
-        self.tFirst = d[2]
-        self.tLast = self.tFirst
+        self.t_first= d[2]
+        self.t_last= self.t_first
 
     def update(self, d: t.List):
         assert(self.name == d[0])
 
         self.email.add(d[1])
         t = d[2]
-        if t < self.tFirst:
-            self.tFirst = t
-        elif t > self.tFirst:
-            self.tLast = t
+        if t < self.t_first:
+            self.t_first = t
+        elif t > self.t_first:
+            self.t_last = t
+
 
 def harvest_git(click_ctx: click.Context, ctx: HermesHarvestContext):
     """
@@ -46,20 +48,20 @@ def harvest_git(click_ctx: click.Context, ctx: HermesHarvestContext):
         raise RuntimeError('No parent context!')
     path = parent_ctx.params['path']
 
-    gitExe = shutil.which('git')
-    if not gitExe:
+    git_exe = shutil.which('git')
+    if not git_exe:
         raise RuntimeError('Git not available!')
 
-    p = subprocess.run([gitExe, "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True)
+    p = subprocess.run([git_exe, "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True)
     if p.returncode:
         raise RuntimeError("`git branch` command failed with code {}: '{}'!".format(p.returncode, p.stderr.decode(SHELL_ENCODING)))
-    gitBranch = p.stdout.decode(SHELL_ENCODING).strip()
+    git_branch = p.stdout.decode(SHELL_ENCODING).strip()
     # TODO: should we warn or error if the HEAD is detached?
 
     # Get history of currently checked-out branch
     authors = {}
     committers = {}
-    p = subprocess.run([gitExe, "log", "--pretty=%an_%ae_%at_%cn_%ce_%ct"], capture_output=True)
+    p = subprocess.run([git_exe, "log", "--pretty=%an_%ae_%at_%cn_%ce_%ct"], capture_output=True)
     if p.returncode:
         raise RuntimeError("`git log` command failed with code {}: '{}'!".format(p.returncode, p.stderr.decode(SHELL_ENCODING)))
 
@@ -76,18 +78,19 @@ def harvest_git(click_ctx: click.Context, ctx: HermesHarvestContext):
         _updateContributor(authors, d[0:3])
         _updateContributor(committers, d[3:7])
     
-    _ctxUpdateContributors(ctx, authors, "author", branch=gitBranch)
-    _ctxUpdateContributors(ctx, committers, "committer", branch=gitBranch)
+    _ctx_update_contributors(ctx, authors, "author", branch=git_branch)
+    _ctx_update_contributors(ctx, committers, "committer", branch=git_branch)
 
-def _updateContributor(contributors: t.Dict, d: t.List):
+def _update_contributor(contributors: t.Dict, d: t.List):
     if d[0] in contributors:
         contributors[d[0]].update(d[0:3])
     else:
         contributors[d[0]] = ConributorData(d[0:3])
 
-def _ctxUpdateContributors(ctx: HermesHarvestContext, contributors: t.Dict, kind: str, **kwargs):
+
+def _ctx_update_contributors(ctx: HermesHarvestContext, contributors: t.Dict, kind: str, **kwargs):
     for a in contributors.values():
-        ctx.update(f"{kind}.since", a.tFirst, name=a.name, **kwargs)
-        ctx.update(f"{kind}.until", a.tLast, name=a.name, **kwargs)
+        ctx.update(f"{kind}.since", a.t_first, name=a.name, **kwargs)
+        ctx.update(f"{kind}.until", a.t_last, name=a.name, **kwargs)
         for e in a.email:
             ctx.update(f"{kind}.email", e, name=a.name, email=e, **kwargs)

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -17,7 +17,7 @@ from hermes.model.errors import HermesValidationError
 SHELL_ENCODING = 'utf-8'
 
 class AuthorData:
-    def __init__(self, line):
+    def __init__(self, line: t.List):
         self.name = line[0]
         self.email = set((line[1],))
         self.tFirst = line[2]

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -1,0 +1,84 @@
+import glob
+import os
+import json
+import pathlib
+import urllib.request
+import typing as t
+
+import jsonschema
+import click
+import subprocess
+import shutil
+
+from hermes.model.context import HermesHarvestContext
+from hermes.model.errors import HermesValidationError
+
+# TODO: can and should we get this somehow?
+SHELL_ENCODING = 'utf-8'
+
+class AuthorData:
+    def __init__(self, line):
+        self.name = line[0]
+        self.email = set((line[1],))
+        self.tFirst = line[2]
+        self.tLast = self.tFirst
+
+    def update(self, line: t.List):
+        assert(self.name == line[0])
+
+        self.email.add(line[1])
+        t = line[2]
+        if t < self.tFirst:
+            self.tFirst = t
+        elif t > self.tFirst:
+            self.tLast = t
+
+def harvest_git(click_ctx: click.Context, ctx: HermesHarvestContext):
+    """
+    Implementation of a harvester that provides autor data from Git.
+
+    :param click_ctx: Click context that this command was run inside (might be used to extract command line arguments).
+    :param ctx: The harvesting context that should contain the provided metadata.
+    """
+    # Get the parent context (every subcommand has its own context with the main click context as parent)
+    parent_ctx = click_ctx.parent
+    if parent_ctx is None:
+        raise RuntimeError('No parent context!')
+    path = parent_ctx.params['path']
+
+    gitExe = shutil.which('git')
+    if not gitExe:
+        raise RuntimeError('Git not available!')
+
+    p = subprocess.run([gitExe, "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True)
+    if p.returncode:
+        raise RuntimeError("`git branch` command failed with code {}: '{}'!".format(p.returncode, p.stderr.decode(SHELL_ENCODING)))
+    gitBranch = p.stdout.decode(SHELL_ENCODING).strip()
+    # TODO: should we warn or error if the HEAD is detached?
+
+    # Get history of currently checked-out branch
+    authors = {}
+    p = subprocess.run([gitExe, "log", "--pretty=%an_%ae_%ad", "--date=unix"], capture_output=True)
+    if p.returncode:
+        raise RuntimeError("`git log` command failed with code {}: '{}'!".format(p.returncode, p.stderr.decode(SHELL_ENCODING)))
+
+    log = p.stdout.decode(SHELL_ENCODING).split('\n')
+    for l in log:
+        d = l.split('_')
+        if len(d) != 3:
+            continue
+        try:
+            d[2] = int(d[2])
+        except ValueError:
+            continue
+
+        if d[0] in authors:
+            authors[d[0]].update(d)
+        else:
+            authors[d[0]] = AuthorData(d)
+    
+    for a in authors.values():
+        ctx.update("author.since", a.tFirst, name=a.name, branch=gitBranch)
+        ctx.update("author.until", a.tLast, name=a.name, branch=gitBranch)
+        for e in a.email:
+            ctx.update("author.email", e, name=a.name, branch=gitBranch, email=e)


### PR DESCRIPTION
This patch adds a harvester that collects some authorship data from git history.

I am not sure how to put the *set* of authors and their (potential) *set* of email addresses into the `HermesHarvestContext`. Using the available array pattern does not work, because order of authors and email addresses may change between runs if the history contains new commits or when run on a different branch (likewise when sorting by name, if a new author joined).

In this version, I solved this by adding the author name as a tag value, rather than as value, because tags act like a set. This leads to a weird pattern for the email, where the address is also a tag value, to get a set, but also a value (same as would happen with an `author.name` key).