### PR TITLE
Fix full term for ADR in docs

### DIFF
--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2022 German Aerospace Center (DLR), Forschungszentrum JÃ
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->
 
-# Architecture Design Records
+# Architectural Decision Records
 
 ```{toctree}
 :glob:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,3 +16,4 @@ sphinx-icon==0.1.2
 sphinx-favicon==0.2
 sphinxemoji==0.2.0
 sphinxext-opengraph==0.6.3 
+sphinx-autoapi==2.0.0


### PR DESCRIPTION
The docs still call ADRs _Architecture Design Records_ instead of the correct _Architectural Decision Records_. This PR fixes that, and also adds a missing extension to the docs `requirements.txt` (that we need because Sphinx won't play nice with poetry yet).

To test, do

```bash
# On develop to see the error
cd docs
python3.11 -m venv venv
. venv/bin/activate
make deps && make livehtml

# Error:
# Running Sphinx v4.5.0
# loading translations [en]... done
#
# Extension error:
# Could not import extension autoapi.extension (exception: No module named 'autoapi')

git switch feature/fix-terminology-in-docs

rm -rf venv/
python3.11 -m venv venv
. venv/bin/activate

make deps && make livehtml
# Installs and builds without errors
```
