### PR TITLE
Fix #85: Improve email mapping terminology

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,10 +1,10 @@
 # Mapping of email addresses only. Format (one pair per line):
-# <old.email@ddress> <new.email@address>
+# <primary.email@address> <discard.this.email@address>
 <michael.meinel@dlr.de> <led02@me.com>
 <o.bertuch@fz-juelich.de> <poikilotherm@users.noreply.github.com>
 <stephan.druskat@dlr.de> <sdruskat@users.noreply.github.com>
 
 # Mapping of user names. Format (one pair per line):
-# Real Name <email@ddress> nickname
-# Real Name <email@ddress> Name, Real
+# Real Name <email@address> nickname
+# Real Name <email@address> Name, Real
 Jeffrey Kelling <j.kelling@hzdr.de> jkelling


### PR DESCRIPTION
- Although this file was used initially for dogfooding and isn't part of documentation anymore, this is a relevant meta file for our project as a software project as such, and is therefore kept.
- The proposed example strings replace the original strings, and typos are fixed

Fixes #85