### PR TITLE
Rename post to postprocess in various places

### DIFF
--- a/src/hermes/cli.py
+++ b/src/hermes/cli.py
@@ -140,7 +140,7 @@ class WorkflowCommand(click.Group):
 
 @click.group(cls=WorkflowCommand, invoke_without_command=True)
 @click.option("--deposit", is_flag=True, default=False)
-@click.option("--post-process", is_flag=True, default=False)
+@click.option("--postprocess", is_flag=True, default=False)
 @click.option('--path', default=pathlib.Path('./'), help='Working path', type=pathlib.Path)
 @click.pass_context
 def main(ctx: click.Context, *args, **kwargs) -> None:

--- a/src/hermes/cli.py
+++ b/src/hermes/cli.py
@@ -140,7 +140,7 @@ class WorkflowCommand(click.Group):
 
 @click.group(cls=WorkflowCommand, invoke_without_command=True)
 @click.option("--deposit", is_flag=True, default=False)
-@click.option("--post", is_flag=True, default=False)
+@click.option("--post-process", is_flag=True, default=False)
 @click.option('--path', default=pathlib.Path('./'), help='Working path', type=pathlib.Path)
 @click.pass_context
 def main(ctx: click.Context, *args, **kwargs) -> None:
@@ -156,4 +156,4 @@ def main(ctx: click.Context, *args, **kwargs) -> None:
 main.add_command(workflow.harvest)
 main.add_command(workflow.process)
 main.add_command(workflow.deposit)
-main.add_command(workflow.post)
+main.add_command(workflow.postprocess)

--- a/src/hermes/commands/process/cff.py
+++ b/src/hermes/commands/process/cff.py
@@ -13,7 +13,7 @@ def add_name(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
     """
     Augment each author with a `name` attribute (if not present).
 
-    This will allow better matching against the git authors and can be removed in a post-process step.
+    This will allow better matching against the git authors and can be removed in a post-processing step.
 
     :param ctx: The resulting context that should contain the harmonized data.
     :param harvest_ctx: The harvest context containing all raw harvested data.

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -117,7 +117,7 @@ def deposit():
 
 
 @click.group(invoke_without_command=True)
-def post():
+def post_process():
     """
     Post-process metadata after deposition
     """

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -117,8 +117,8 @@ def deposit():
 
 
 @click.group(invoke_without_command=True)
-def post_process():
+def postprocess():
     """
-    Post-process metadata after deposition
+    Postprocess metadata after deposition
     """
     click.echo("Post-processing")

--- a/test/hermes_test/test_cli.py
+++ b/test/hermes_test/test_cli.py
@@ -101,9 +101,9 @@ def test_hermes_with_deposit():
     assert not result.exception
 
 
-def test_haggis_with_post_process():
+def test_haggis_with_postprocess():
     runner = CliRunner()
-    result = runner.invoke(cli.main, args=('--post-process', ))
+    result = runner.invoke(cli.main, args=('--postprocess', ))
 
     assert not result.exception
 
@@ -115,9 +115,9 @@ def test_hermes_with_path():
     assert not result.exception
 
 
-def test_hermes_with_deposit_and_post_process():
+def test_haggis_with_deposit_and_postprocess():
     runner = CliRunner()
-    result = runner.invoke(cli.main, args=('--deposit', '--post-process'))
+    result = runner.invoke(cli.main, args=('--deposit', '--postprocess'))
 
     assert not result.exception
 
@@ -129,15 +129,15 @@ def test_hermes_with_deposit_and_path():
     assert not result.exception
 
 
-def test_hermes_with_path_and_post_process():
+def test_haggis_with_path_and_postprocess():
     runner = CliRunner()
-    result = runner.invoke(cli.main, args=('--path', './', '--post-process'))
+    result = runner.invoke(cli.main, args=('--path', './', '--postprocess'))
 
     assert not result.exception
 
 
-def test_hermes_with_deposit_and_post_process_and_path():
+def test_haggis_with_deposit_and_postprocess_and_path():
     runner = CliRunner()
-    result = runner.invoke(cli.main, args=('--deposit', '--post-process', '--path', './'))
+    result = runner.invoke(cli.main, args=('--deposit', '--postprocess', '--path', './'))
 
     assert not result.exception

--- a/test/hermes_test/test_cli.py
+++ b/test/hermes_test/test_cli.py
@@ -101,9 +101,9 @@ def test_hermes_with_deposit():
     assert not result.exception
 
 
-def test_hermes_with_post():
+def test_haggis_with_post_process():
     runner = CliRunner()
-    result = runner.invoke(cli.main, args=('--post', ))
+    result = runner.invoke(cli.main, args=('--post-process', ))
 
     assert not result.exception
 
@@ -115,9 +115,9 @@ def test_hermes_with_path():
     assert not result.exception
 
 
-def test_hermes_with_deposit_and_post():
+def test_hermes_with_deposit_and_post_process():
     runner = CliRunner()
-    result = runner.invoke(cli.main, args=('--deposit', '--post'))
+    result = runner.invoke(cli.main, args=('--deposit', '--post-process'))
 
     assert not result.exception
 
@@ -129,15 +129,15 @@ def test_hermes_with_deposit_and_path():
     assert not result.exception
 
 
-def test_hermes_with_path_and_post():
+def test_hermes_with_path_and_post_process():
     runner = CliRunner()
-    result = runner.invoke(cli.main, args=('--path', './', '--post'))
+    result = runner.invoke(cli.main, args=('--path', './', '--post-process'))
 
     assert not result.exception
 
 
-def test_hermes_with_deposit_and_post_and_path():
+def test_hermes_with_deposit_and_post_process_and_path():
     runner = CliRunner()
-    result = runner.invoke(cli.main, args=('--deposit', '--post', '--path', './'))
+    result = runner.invoke(cli.main, args=('--deposit', '--post-process', '--path', './'))
 
     assert not result.exception


### PR DESCRIPTION
This pull request renames "post" to "postprocess" in various places. This helps distinguishing it from the verb "to post" which is not what it does. Also, it makes sure that the noun "post-processing" is spelled with a hyphen, and the verb is spelled without a hyphen.