### PR TITLE
Implement constant common default timestamp

### DIFF
--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -35,6 +35,8 @@ class HermesContext:
     - The *harvest* stages uses :class:`HermesHarvestContext`.
     """
 
+    default_timestamp = datetime.datetime.now().isoformat(timespec='seconds')
+
     def __init__(self, project_dir: t.Optional[Path] = None):
         """
         Create a new context for the given project dir.
@@ -195,7 +197,7 @@ class HermesHarvestContext(HermesContext):
         See :py:meth:`HermesContext.update` for more information.
         """
 
-        timestamp = kwargs.pop('timestamp', datetime.datetime.now().isoformat(timespec='seconds'))
+        timestamp = kwargs.pop('timestamp', self.default_timestamp)
         harvester = kwargs.pop('harvester', self._ep.name)
 
         if _key not in self._data:

--- a/test/hermes_test/model/test_harvest_context.py
+++ b/test/hermes_test/model/test_harvest_context.py
@@ -4,7 +4,6 @@
 
 # SPDX-FileContributor: Michael Meinel
 
-from datetime import datetime
 from importlib.metadata import EntryPoint
 
 import pytest

--- a/test/hermes_test/model/test_harvest_context.py
+++ b/test/hermes_test/model/test_harvest_context.py
@@ -26,7 +26,7 @@ def test_context_default(harvest_ctx):
 
     assert harvest_ctx._data['spam'] == [
         ['eggs', {'test': True,
-                  'timestamp': datetime.now().isoformat(timespec='seconds'),
+                  'timestamp': HermesContext.default_timestamp,
                   'harvester': 'test_context_default'}]
     ]
 
@@ -37,10 +37,10 @@ def test_context_update_append(harvest_ctx):
 
     assert harvest_ctx._data['spam'] == [
         ['noodles', {'index': 0,
-                     'timestamp': datetime.now().isoformat(timespec='seconds'),
+                     'timestamp': HermesContext.default_timestamp,
                      'harvester': 'test_context_update_append'}],
         ['eggs', {'index': 1,
-                  'timestamp': datetime.now().isoformat(timespec='seconds'),
+                  'timestamp': HermesContext.default_timestamp,
                   'harvester': 'test_context_update_append'}]
     ]
 
@@ -51,7 +51,7 @@ def test_context_update_replace(harvest_ctx):
 
     assert harvest_ctx._data['spam'] == [
         ['eggs', {'test': True,
-                  'timestamp': datetime.now().isoformat(timespec='seconds'),
+                  'timestamp': HermesContext.default_timestamp,
                   'harvester': 'test_context_update_replace'}]
     ]
 
@@ -64,12 +64,12 @@ def test_context_bulk_flat(harvest_ctx):
 
     assert harvest_ctx._data['ans'] == [
         [42, {'test': True,
-              'timestamp': datetime.now().isoformat(timespec='seconds'),
+              'timestamp': HermesContext.default_timestamp,
               'harvester': 'test_context_bulk_flat'}]
     ]
     assert harvest_ctx._data['spam'] == [
         ['eggs', {'test': True,
-                  'timestamp': datetime.now().isoformat(timespec='seconds'),
+                  'timestamp': HermesContext.default_timestamp,
                   'harvester': 'test_context_bulk_flat'}]
     ]
 
@@ -85,20 +85,22 @@ def test_context_bulk_complex(harvest_ctx):
 
     assert harvest_ctx._data['ans'] == [
         [42, {'test': True,
-              'timestamp': datetime.now().isoformat(timespec='seconds'),
+              'timestamp': HermesContext.default_timestamp,
               'harvester': 'test_context_bulk_complex'}]
     ]
     assert harvest_ctx._data['author[0].name'] == [
-        ['Monty Python', {'test': True, 'timestamp': datetime.now().isoformat(timespec='seconds'),
+        ['Monty Python', {'test': True,
+                          'timestamp': HermesContext.default_timestamp,
                           'harvester': 'test_context_bulk_complex'}]
     ]
     assert harvest_ctx._data['author[0].email'] == [
-        ['eggs@spam.io', {'test': True, 'timestamp': datetime.now().isoformat(timespec='seconds'),
+        ['eggs@spam.io', {'test': True,
+                          'timestamp': HermesContext.default_timestamp,
                           'harvester': 'test_context_bulk_complex'}]
     ]
     assert harvest_ctx._data['author[1].name'] == [
         ['Herr Mes', {'test': True,
-                      'timestamp': datetime.now().isoformat(timespec='seconds'),
+                      'timestamp': HermesContext.default_timestamp,
                       'harvester': 'test_context_bulk_complex'}]
     ]
 
@@ -109,11 +111,12 @@ def test_context_bulk_replace(harvest_ctx):
 
     assert harvest_ctx._data['author[0].name'] == [
         ['Herr Mes', {'test': True,
-                      'timestamp': datetime.now().isoformat(timespec='seconds'),
+                      'timestamp': HermesContext.default_timestamp,
                       'harvester': 'test_context_bulk_replace'}]
     ]
     assert harvest_ctx._data['author[0].email'] == [
-        ['eggs@spam.io', {'test': True, 'timestamp': datetime.now().isoformat(timespec='seconds'),
+        ['eggs@spam.io', {'test': True,
+                          'timestamp': HermesContext.default_timestamp,
                           'harvester': 'test_context_bulk_replace'}]
     ]
 
@@ -123,13 +126,15 @@ def test_context_bulk_append(harvest_ctx):
     harvest_ctx.update_from({'author': [{'name': 'Herr Mes', 'email': 'eggs@spam.io'}]}, index=1)
 
     assert harvest_ctx._data['author[0].name'] == [
-        ['Monty Python', {'index': 0, 'timestamp': datetime.now().isoformat(timespec='seconds'),
+        ['Monty Python', {'index': 0,
+                          'timestamp': HermesContext.default_timestamp,
                           'harvester': 'test_context_bulk_append'}],
         ['Herr Mes', {'index': 1,
-                      'timestamp': datetime.now().isoformat(timespec='seconds'),
+                      'timestamp': HermesContext.default_timestamp,
                       'harvester': 'test_context_bulk_append'}]
     ]
     assert harvest_ctx._data['author[0].email'] == [
-        ['eggs@spam.io', {'index': 1, 'timestamp': datetime.now().isoformat(timespec='seconds'),
+        ['eggs@spam.io', {'index': 1,
+                          'timestamp': HermesContext.default_timestamp,
                           'harvester': 'test_context_bulk_append'}]
     ]


### PR DESCRIPTION
The default timestamp is implemented as static field of the HermesContext base class and is thus accessible everywhere and everytime

Closes #97