### PR TITLE
Fix #65: Add git authors and committers as contributors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ hermes = "hermes.cli:main"
 
 [tool.poetry.plugins."hermes.preprocess"]
 000_cff = "hermes.commands.process.cff:add_name"
-020_git = "hermes.commands.process.git:flag_authors"
+020_git = "hermes.commands.process.git:add_contributors"
 
 
 

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -4,6 +4,7 @@
 
 # SPDX-FileContributor: Jeffrey Kelling
 # SPDX-FileContributor: Michael Meinel
+# SPDX-FileContributor: Stephan Druskat
 
 import logging
 import os

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -134,7 +134,7 @@ class ContributorData:
 
 class NodeRegister:
     """
-    Helper class to unify Git commit authors / committers.
+    Helper class to unify Git commit authors and committers.
 
     This class keeps track of all registered instances and merges two :py:class:`ContributorData` instances if some
     attributes match.

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -133,7 +133,7 @@ class ContributorData:
 
 class NodeRegister:
     """
-    Helper class to unify Git commit authors / contributors.
+    Helper class to unify Git commit authors / committers.
 
     This class keeps track of all registered instances and merges two :py:class:`ContributorData` instances if some
     attributes match.

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -240,7 +240,7 @@ def _audit_contributors(contributors, audit_log: logging.Logger):
 
 def _merge_contributors(git_authors: NodeRegister, git_committers: NodeRegister) -> NodeRegister:
     """
-    Merges the git authors and git committers :py:class:`NodeRegister`s, and assign the respective roles for each node.
+    Merges the git authors and git committers :py:class:`NodeRegister` and assign the respective roles for each node.
     """
     git_contributors = NodeRegister(ContributorData, 'email', 'name', email=str.upper)
     for author in git_authors._all:

--- a/src/hermes/commands/process/git.py
+++ b/src/hermes/commands/process/git.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # SPDX-FileContributor: Michael Meinel
+# SPDX-FileContributor: Stephan Druskat
 
 import logging
 

--- a/src/hermes/commands/process/git.py
+++ b/src/hermes/commands/process/git.py
@@ -14,14 +14,14 @@ _AUTHOR_KEYS = ('@id', 'email', 'name')
 
 def flag_authors(ctx: CodeMetaContext, harverst_ctx: HermesHarvestContext):
     """
-    Identify all authors that are not yet in the target context and flag them with role `Contributor`.
+    Add all git authors and committers with role `Contributor`.
 
     :param ctx: The target context containting harmonized data.
     :param harverst_ctx: Data as it was harvested.
     """
     audit_log = logging.getLogger('audit.git')
     audit_log.info('')
-    audit_log.info('### Flag new authors')
+    audit_log.info('### Add git authors and committers as contributors')
 
     author_path = ContextPath('author')
     contributor_path = ContextPath('contributor')
@@ -34,16 +34,10 @@ def flag_authors(ctx: CodeMetaContext, harverst_ctx: HermesHarvestContext):
         return
 
     for i, contributor in enumerate(author_path.get_from(data)):
-        query = {k: contributor[k] for k in _AUTHOR_KEYS if k in contributor}
-        author_key, target, path = author_path['*'].resolve(ctx._data, query=query)
-
-        if author_key._item == '*':
-            audit_log.debug('- %s', contributor['name'])
-            if contributor_path not in ctx.keys():
-                ctx.update(contributor_path, [])
-            ctx.update(contributor_path['*'], contributor, tags=tags)
-        else:
-            ctx.update(author_key, contributor, tags=tags)
+        audit_log.debug('- %s', contributor['name'])
+        if contributor_path not in ctx.keys():
+            ctx.update(contributor_path, [])
+        ctx.update(contributor_path['*'], contributor, tags=tags)
 
     ctx.tags.update(tags)
     harverst_ctx.finish()

--- a/src/hermes/commands/process/git.py
+++ b/src/hermes/commands/process/git.py
@@ -13,7 +13,7 @@ from hermes.model.context import CodeMetaContext, HermesHarvestContext, ContextP
 _AUTHOR_KEYS = ('@id', 'email', 'name')
 
 
-def flag_authors(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
+def add_contributors(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
     """
     Add all git authors and committers with role `Contributor`.
 
@@ -24,7 +24,6 @@ def flag_authors(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
     audit_log.info('')
     audit_log.info('### Add git authors and committers as contributors')
 
-    author_path = ContextPath('author')
     contributor_path = ContextPath('contributor')
 
     tags = {}
@@ -34,7 +33,7 @@ def flag_authors(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
         audit_log.info("- Inconsistent data, skipping.")
         return
 
-    for i, contributor in enumerate(author_path.get_from(data)):
+    for i, contributor in enumerate(contributor_path.get_from(data)):
         audit_log.debug('- %s', contributor['name'])
         if contributor_path not in ctx.keys():
             ctx.update(contributor_path, [])

--- a/src/hermes/commands/process/git.py
+++ b/src/hermes/commands/process/git.py
@@ -13,7 +13,7 @@ from hermes.model.context import CodeMetaContext, HermesHarvestContext, ContextP
 _AUTHOR_KEYS = ('@id', 'email', 'name')
 
 
-def flag_authors(ctx: CodeMetaContext, harverst_ctx: HermesHarvestContext):
+def flag_authors(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
     """
     Add all git authors and committers with role `Contributor`.
 
@@ -29,7 +29,7 @@ def flag_authors(ctx: CodeMetaContext, harverst_ctx: HermesHarvestContext):
 
     tags = {}
     try:
-        data = harverst_ctx.get_data(tags=tags)
+        data = harvest_ctx.get_data(tags=tags)
     except ValueError:
         audit_log.info("- Inconsistent data, skipping.")
         return
@@ -41,4 +41,4 @@ def flag_authors(ctx: CodeMetaContext, harverst_ctx: HermesHarvestContext):
         ctx.update(contributor_path['*'], contributor, tags=tags)
 
     ctx.tags.update(tags)
-    harverst_ctx.finish()
+    harvest_ctx.finish()

--- a/src/hermes/model/path.py
+++ b/src/hermes/model/path.py
@@ -19,7 +19,7 @@ class ContextPathGrammar:
     The pyparsing grammar for ContextGrammar paths.
     """
 
-    key = pp.Word('@' + pp.alphas)
+    key = pp.Word('@:' + pp.alphas)
     index = pp.Word(pp.nums).set_parse_action(lambda tok: [int(tok[0])]) | pp.Char('*')
     field = key + (pp.Suppress('[') + index + pp.Suppress(']'))[...]
     path = field + (pp.Suppress('.') + field)[...]


### PR DESCRIPTION
This PR fixes #65.

For a discussion why this change is necessary, see the issue.

Changes:

- Add all git authors and git committers as contributors.
- Decouple git harvesting and preprocessing from authors, as semantically, we can never assert git contributors to be authors.