### PR TITLE
Remove roles from string output of contributor data

### DIFF
--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -61,8 +61,6 @@ class ContributorData:
             parts.append(self.name[0])
         if self.email:
             parts.append(f'<{self.email[0]}>')
-        if self.role:
-            parts.append(f' ({", ".join([self.role])}')
         return f'"{" ".join(parts)}"'
 
     def _update_attr(self, target, value, unique=True):


### PR DESCRIPTION
The original PR (#107) had been merged before the final push was incorporated. Hence, this PR removes the roles from __str__ output for ContributorData to avoid falling out of line with RFC.