### PR TITLE
Add git branch to harvesting context under hermes schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ hermes = "hermes.cli:main"
 
 [tool.poetry.plugins."hermes.preprocess"]
 000_cff = "hermes.commands.process.cff:add_name"
-020_git = "hermes.commands.process.git:add_contributors"
+020_git = "hermes.commands.process.git:process"
 
 [tool.poetry.plugins."hermes.prepare_deposit"]
 invenio = "hermes.commands.deposit.invenio:prepare_deposit"

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -320,7 +320,7 @@ def harvest_git(click_ctx: click.Context, ctx: HermesHarvestContext):
 
         '@type': "SoftwareSourceCode",
         'contributor': [contributor.to_codemeta() for contributor in git_contributors._all],
-    })
+    }, git_branch=git_branch)
     ctx.update('hermes:gitBranch', git_branch)
 
     try:

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -320,7 +320,8 @@ def harvest_git(click_ctx: click.Context, ctx: HermesHarvestContext):
 
         '@type': "SoftwareSourceCode",
         'contributor': [contributor.to_codemeta() for contributor in git_contributors._all],
-    }, branch=git_branch)
+    })
+    ctx.update('hermes:gitBranch', git_branch)
 
     try:
         ctx.get_data()

--- a/src/hermes/commands/process/git.py
+++ b/src/hermes/commands/process/git.py
@@ -10,7 +10,7 @@ import logging
 from hermes.model.context import CodeMetaContext, HermesHarvestContext, ContextPath
 
 
-_AUTHOR_KEYS = ('@id', 'email', 'name')
+audit_log = logging.getLogger('audit.git')
 
 
 def add_contributors(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
@@ -18,9 +18,8 @@ def add_contributors(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
     Add all git authors and committers with role `Contributor`.
 
     :param ctx: The target context containting harmonized data.
-    :param harverst_ctx: Data as it was harvested.
+    :param harvest_ctx: Data as it was harvested.
     """
-    audit_log = logging.getLogger('audit.git')
     audit_log.info('')
     audit_log.info('### Add git authors and committers as contributors')
 
@@ -40,4 +39,37 @@ def add_contributors(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
         ctx.update(contributor_path['*'], contributor, tags=tags)
 
     ctx.tags.update(tags)
+
+
+def add_branch(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
+    """
+    Add the git branch.
+
+    :param ctx: The target context containting harmonized data.
+    :param harvest_ctx: Data as it was harvested.
+    """
+    audit_log.info('')
+    audit_log.info('### Add git branch')
+
+    branch_path = ContextPath('hermes:gitBranch')
+
+    tags = {}
+    try:
+        data = harvest_ctx.get_data(tags=tags)
+    except ValueError:
+        audit_log.info("- Inconsistent data, skipping.")
+        return
+
+    branch = branch_path.get_from(data)
+    audit_log.debug('- %s', branch)
+    if branch_path not in ctx.keys():
+        ctx.update(branch_path, None)
+    ctx.update(branch_path, branch, tags=tags)
+
+    ctx.tags.update(tags)
     harvest_ctx.finish()
+
+
+def process(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
+    add_contributors(ctx, harvest_ctx)
+    add_branch(ctx, harvest_ctx)

--- a/src/hermes/commands/process/git.py
+++ b/src/hermes/commands/process/git.py
@@ -67,9 +67,9 @@ def add_branch(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
     ctx.update(branch_path, branch, tags=tags)
 
     ctx.tags.update(tags)
-    harvest_ctx.finish()
 
 
 def process(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
     add_contributors(ctx, harvest_ctx)
     add_branch(ctx, harvest_ctx)
+    harvest_ctx.finish()

--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -130,10 +130,10 @@ class HermesContext:
         if data is None:
             data = {}
         if path is not None:
-            data.update(path.get_from(self._data))
+            data.update({str(path): path.get_from(self._data)})
         else:
             for key in self.keys():
-                data.update(key.get_from(self._data))
+                data.update({str(key): key.get_from(self._data)})
         return data
 
     def error(self, ep: EntryPoint, error: Exception):

--- a/test/hermes_test/commands/harvest/test_git.py
+++ b/test/hermes_test/commands/harvest/test_git.py
@@ -94,6 +94,7 @@ Git Author + Committer|e@mail.com|2023-01-13T08:57:12+01:00|Git Author + Committ
 Git Author|f@mail.com|2023-01-13T08:57:12+01:00|Git Committer|g@mail.com|2023-01-13T08:57:12+01:00
     '''
 
+
 @pytest.fixture
 def git_branch_output():
     return 'test-branch'

--- a/test/hermes_test/commands/harvest/test_git.py
+++ b/test/hermes_test/commands/harvest/test_git.py
@@ -81,7 +81,8 @@ def codemeta():
         }
       ]
     }
-  ]
+  ],
+  "hermes:gitBranch": "test-branch"
 }
     """)
 
@@ -93,6 +94,10 @@ Git Author + Committer|e@mail.com|2023-01-13T08:57:12+01:00|Git Author + Committ
 Git Author|f@mail.com|2023-01-13T08:57:12+01:00|Git Committer|g@mail.com|2023-01-13T08:57:12+01:00
     '''
 
+@pytest.fixture
+def git_branch_output():
+    return 'test-branch'
+
 
 @pytest.fixture
 def mock_click_ctx():
@@ -102,7 +107,7 @@ def mock_click_ctx():
 
 
 @patch("hermes.commands.harvest.git.subprocess.run")
-def test_harvest_git(mock_run, mock_click_ctx, harvest_ctx, git_log_output, codemeta):
+def test_harvest_git(mock_run, mock_click_ctx, harvest_ctx, git_log_output, git_branch_output, codemeta):
     # Mocking the output of the subprocess call to git log to retrieve author and committer info
     mock_stdout = Mock()
     mock_stdout.configure_mock(
@@ -114,7 +119,12 @@ def test_harvest_git(mock_run, mock_click_ctx, harvest_ctx, git_log_output, code
 
     # Mocking the output of the subprocess call to git rev-parse to retrieve branch id
     mock_get_branch = Mock()
-    mock_get_branch.returncode = 0
+    mock_get_branch.configure_mock(
+        **{
+            "stdout.decode.return_value": git_branch_output,
+            "returncode": 0
+        }
+    )
 
     # Define outputs from "running" the subprocess mock
     mock_run.side_effect = [mock_get_branch, mock_stdout]

--- a/test/hermes_test/commands/process/test_git.py
+++ b/test/hermes_test/commands/process/test_git.py
@@ -63,5 +63,10 @@ def test_process_git(harvest_ctx, _data):
     ctx = CodeMetaContext()
     assert ctx.get_data() == {}
     process.process(ctx, harvest_ctx)
-    assert harvest_ctx.get_data() == {}
     assert ctx.get_data() == _data
+
+
+def test_process_git_empties_harvesting_context(harvest_ctx):
+    ctx = CodeMetaContext()
+    process.process(ctx, harvest_ctx)
+    assert harvest_ctx.get_data() == {}

--- a/test/hermes_test/commands/process/test_git.py
+++ b/test/hermes_test/commands/process/test_git.py
@@ -9,121 +9,60 @@ from importlib.metadata import EntryPoint
 
 import pytest
 from pytest import FixtureRequest
-from unittest.mock import patch, Mock
 
-import hermes.commands.harvest.git as harvest
-from hermes.model.context import HermesContext, CodeMetaContext
-
-
-@pytest.fixture
-def harvest_ctx(request: FixtureRequest):
-    ctx = HermesContext()
-    return CodeMetaContext(
-        ctx,
-        EntryPoint(name=request.function.__name__, group='hermes.process', value='hermes_test:ctx')
-    )
+import hermes.commands.process.git as process
+from hermes.model.context import HermesContext, HermesHarvestContext, CodeMetaContext
 
 
 @pytest.fixture
-def codemeta():
-    return json.loads("""
-{
-  "contributor": [
-    {
-      "@type": "Person",
-      "name": "Git Author + Committer",
-      "email": "e@mail.com",
-      "hermes:contributionRole": [
-        {
-          "@type": "Role",
-          "roleName": "git author",
-          "startTime": "2023-01-13T08:57:12+01:00",
-          "endTime": "2023-01-13T08:57:12+01:00"
-        },
-        {
-          "@type": "Role",
-          "roleName": "git committer",
-          "startTime": "2023-01-13T08:57:12+01:00",
-          "endTime": "2023-01-13T08:57:12+01:00"
-        }
-      ]
-    },
-    {
-      "@type": "Person",
-      "name": "Git Author",
-      "email": "f@mail.com",
-      "hermes:contributionRole": [
-        {
-          "@type": "Role",
-          "roleName": "git author",
-          "startTime": "2023-01-13T08:57:12+01:00",
-          "endTime": "2023-01-13T08:57:12+01:00"
-        }
-      ]
-    },
-    {
-      "@type": "Person",
-      "name": "Git Committer",
-      "email": "g@mail.com",
-      "hermes:contributionRole": [
-        {
-          "@type": "Role",
-          "roleName": "git committer",
-          "startTime": "2023-01-13T08:57:12+01:00",
-          "endTime": "2023-01-13T08:57:12+01:00"
-        }
-      ]
+def _data():
+    return {
+        'contributor': [
+            {
+                '@type': 'Person',
+                'name': 'Git Author',
+                'email': 'f@mail.com',
+                'contributionRole': [
+                    {
+                        '@type': 'Role',
+                        'roleName': 'git author',
+                        'startTime': '2023-01-13T08:57:12+01:00',
+                        'endTime': '2023-01-13T08:57:12+01:00'
+                    }
+                ]
+            },
+            {
+                '@type': 'Person',
+                'name': 'Git Committer',
+                'email': 'c@mail.com',
+                'contributionRole': [
+                    {
+                        '@type': 'Role',
+                        'roleName': 'git committer',
+                        'startTime': '2023-01-13T08:57:12+01:00',
+                        'endTime': '2023-01-13T08:57:12+01:00'
+                    }
+                ]
+            }
+        ],
+        'hermes:gitBranch': 'test-branch'
     }
-  ],
-  "hermes:gitBranch": "test-branch"
-}
-    """)
 
 
 @pytest.fixture
-def git_log_output():
-    return '''
-Git Author + Committer|e@mail.com|2023-01-13T08:57:12+01:00|Git Author + Committer|e@mail.com|2023-01-13T08:57:12+01:00
-Git Author|f@mail.com|2023-01-13T08:57:12+01:00|Git Committer|g@mail.com|2023-01-13T08:57:12+01:00
-    '''
-
-
-@pytest.fixture
-def git_branch_output():
-    return 'test-branch'
-
-
-@pytest.fixture
-def mock_click_ctx():
-    ctx = Mock()
-    ctx.parent = Mock(params={'path': '.'})
-    return ctx
-
-
-@patch("hermes.commands.harvest.git.subprocess.run")
-def test_harvest_git(mock_run, mock_click_ctx, harvest_ctx, git_log_output, git_branch_output, codemeta):
-    # Mocking the output of the subprocess call to git log to retrieve author and committer info
-    mock_stdout = Mock()
-    mock_stdout.configure_mock(
-        **{
-            "stdout.decode.return_value": git_log_output,
-            "returncode": 0
-        }
+def harvest_ctx(request: FixtureRequest, _data):
+    _ctx = HermesContext()
+    harvest_ctx = HermesHarvestContext(
+        _ctx,
+        EntryPoint(name=request.function.__name__, group='hermes.harvest', value='hermes_test:ctx')
     )
+    harvest_ctx.update_from(_data)
+    return harvest_ctx
 
-    # Mocking the output of the subprocess call to git rev-parse to retrieve branch id
-    mock_get_branch = Mock()
-    mock_get_branch.configure_mock(
-        **{
-            "stdout.decode.return_value": git_branch_output,
-            "returncode": 0
-        }
-    )
 
-    # Define outputs from "running" the subprocess mock
-    mock_run.side_effect = [mock_get_branch, mock_stdout]
-
-    harvest.harvest_git(mock_click_ctx, harvest_ctx)
-
-    result = harvest_ctx.get_data()
-    assert result == codemeta
+def test_process_git(harvest_ctx, _data):
+    ctx = CodeMetaContext()
+    assert ctx.get_data() == {}
+    process.process(ctx, harvest_ctx)
+    assert harvest_ctx.get_data() == {}
+    assert ctx.get_data() == _data

--- a/test/hermes_test/commands/process/test_git.py
+++ b/test/hermes_test/commands/process/test_git.py
@@ -4,7 +4,6 @@
 
 # SPDX-FileContributor: Stephan Druskat
 
-import json
 from importlib.metadata import EntryPoint
 
 import pytest

--- a/test/hermes_test/commands/process/test_git.py
+++ b/test/hermes_test/commands/process/test_git.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2022 German Aerospace Center (DLR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# SPDX-FileContributor: Stephan Druskat
+
+import json
+from importlib.metadata import EntryPoint
+
+import pytest
+from pytest import FixtureRequest
+from unittest.mock import patch, Mock
+
+import hermes.commands.harvest.git as harvest
+from hermes.model.context import HermesContext, CodeMetaContext
+
+
+@pytest.fixture
+def harvest_ctx(request: FixtureRequest):
+    ctx = HermesContext()
+    return CodeMetaContext(
+        ctx,
+        EntryPoint(name=request.function.__name__, group='hermes.process', value='hermes_test:ctx')
+    )
+
+
+@pytest.fixture
+def codemeta():
+    return json.loads("""
+{
+  "contributor": [
+    {
+      "@type": "Person",
+      "name": "Git Author + Committer",
+      "email": "e@mail.com",
+      "hermes:contributionRole": [
+        {
+          "@type": "Role",
+          "roleName": "git author",
+          "startTime": "2023-01-13T08:57:12+01:00",
+          "endTime": "2023-01-13T08:57:12+01:00"
+        },
+        {
+          "@type": "Role",
+          "roleName": "git committer",
+          "startTime": "2023-01-13T08:57:12+01:00",
+          "endTime": "2023-01-13T08:57:12+01:00"
+        }
+      ]
+    },
+    {
+      "@type": "Person",
+      "name": "Git Author",
+      "email": "f@mail.com",
+      "hermes:contributionRole": [
+        {
+          "@type": "Role",
+          "roleName": "git author",
+          "startTime": "2023-01-13T08:57:12+01:00",
+          "endTime": "2023-01-13T08:57:12+01:00"
+        }
+      ]
+    },
+    {
+      "@type": "Person",
+      "name": "Git Committer",
+      "email": "g@mail.com",
+      "hermes:contributionRole": [
+        {
+          "@type": "Role",
+          "roleName": "git committer",
+          "startTime": "2023-01-13T08:57:12+01:00",
+          "endTime": "2023-01-13T08:57:12+01:00"
+        }
+      ]
+    }
+  ],
+  "hermes:gitBranch": "test-branch"
+}
+    """)
+
+
+@pytest.fixture
+def git_log_output():
+    return '''
+Git Author + Committer|e@mail.com|2023-01-13T08:57:12+01:00|Git Author + Committer|e@mail.com|2023-01-13T08:57:12+01:00
+Git Author|f@mail.com|2023-01-13T08:57:12+01:00|Git Committer|g@mail.com|2023-01-13T08:57:12+01:00
+    '''
+
+
+@pytest.fixture
+def git_branch_output():
+    return 'test-branch'
+
+
+@pytest.fixture
+def mock_click_ctx():
+    ctx = Mock()
+    ctx.parent = Mock(params={'path': '.'})
+    return ctx
+
+
+@patch("hermes.commands.harvest.git.subprocess.run")
+def test_harvest_git(mock_run, mock_click_ctx, harvest_ctx, git_log_output, git_branch_output, codemeta):
+    # Mocking the output of the subprocess call to git log to retrieve author and committer info
+    mock_stdout = Mock()
+    mock_stdout.configure_mock(
+        **{
+            "stdout.decode.return_value": git_log_output,
+            "returncode": 0
+        }
+    )
+
+    # Mocking the output of the subprocess call to git rev-parse to retrieve branch id
+    mock_get_branch = Mock()
+    mock_get_branch.configure_mock(
+        **{
+            "stdout.decode.return_value": git_branch_output,
+            "returncode": 0
+        }
+    )
+
+    # Define outputs from "running" the subprocess mock
+    mock_run.side_effect = [mock_get_branch, mock_stdout]
+
+    harvest.harvest_git(mock_click_ctx, harvest_ctx)
+
+    result = harvest_ctx.get_data()
+    assert result == codemeta


### PR DESCRIPTION
- Fix #120 

This PR adds the harvested git branch to both the harvesting context correctly, and to the CodeMeta context in processing.

@led02: During review, please carefully check the following:

- https://github.com/hermes-hmc/workflow/pull/122/commits/59f6c2b624f2d4ec92e66c6e859bcee10f673651