### PR TITLE
Deposit step for invenio-based platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ invenio = "hermes.commands.deposit.invenio:prepare_deposit"
 [tool.poetry.plugins."hermes.metadata_mapping"]
 invenio = "hermes.commands.deposit.invenio:map_metadata"
 
+[tool.poetry.plugins."hermes.deposit"]
+invenio = "hermes.commands.deposit.invenio:deposit"
+
 [tool.taskipy.tasks]
 docs-build = "poetry run sphinx-build -M html docs/source docs/build -W"
 docs-clean = "poetry run sphinx-build -M clean docs/source docs/build"

--- a/src/hermes/cli.py
+++ b/src/hermes/cli.py
@@ -159,7 +159,3 @@ main.add_command(workflow.harvest)
 main.add_command(workflow.process)
 main.add_command(workflow.deposit)
 main.add_command(workflow.postprocess)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/hermes/cli.py
+++ b/src/hermes/cli.py
@@ -159,3 +159,7 @@ main.add_command(workflow.harvest)
 main.add_command(workflow.process)
 main.add_command(workflow.deposit)
 main.add_command(workflow.postprocess)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hermes/commands/deposit/error.py
+++ b/src/hermes/commands/deposit/error.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# SPDX-FileContributor: David Pape
+
+class DepositionUnauthorizedError(Exception):
+    pass

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -92,13 +92,6 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     deposit = response.json()
     _log.debug("Created deposit: %s", deposit["links"]["html"])
 
-    # ``deposit["metadata"]`` contains a ``prereserve_doi`` field which is a dict like
-    # this: ``{'doi': '10.5072/zenodo.1234567', 'recid': 1234567}``. The ``recid`` can
-    # be used to construct the URL to the record when published:
-    # ``f"https://sandbox.zenodo.org/record/{recid}"``.
-    # TODO: Use the URL and the DOI to update the data in the repo files before
-    # uploading them.
-
     # TODO: When updating existing releases, the files API can be used to delete
     # existing files. GET ``deposit["links"]["files"]`` for a list of ``files`` (names,
     # checksums, ...), then DELETE ``file["links"]["download"]`` for each ``file`` in

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -63,8 +63,9 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     invenio_path = ContextPath.parse("deposit.invenio")
     invenio_ctx = ctx[invenio_path]
 
-    # TODO: Get from environment or parameter to the deposit command. Click?
-    token = environ.get("HERMES_INVENIO_AUTH_TOKEN")
+    # TODO: Get from environment or parameter to the deposit command. This can be done
+    # using Click: https://click.palletsprojects.com/en/8.1.x/options/#values-from-environment-variables
+    token = environ["HERMES_INVENIO_AUTH_TOKEN"]
     click_ctx.session.headers["Authorization"] = f"Bearer {token}"
 
     # TODO: Get this from config or determine from some value (DOI, ...) in config.

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -42,6 +42,9 @@ def map_metadata(ctx: CodeMetaContext):
     metadata_path = ContextPath.parse("deposit.invenio.depositionMetadata")
     ctx.update(metadata_path, deposition_metadata)
 
+def deposit(ctx: CodeMetaContext):
+    pass
+
 
 def _request_json(url: str) -> dict:
     """Request an URL and return the JSON response as dict."""

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -5,7 +5,7 @@
 # SPDX-FileContributor: David Pape
 
 from datetime import date
-from getpass import getpass
+from os import environ
 
 import click
 import requests
@@ -58,8 +58,8 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     invenio_path = ContextPath.parse("deposit.invenio")
     invenio_ctx = ctx[invenio_path]
 
-    # TODO: Get from environment or parameter
-    token = getpass(f"API token for {invenio_ctx['siteUrl']}: ")
+    # TODO: Get from environment or parameter to the deposit command. Click?
+    token = environ.get("HERMES_INVENIO_AUTH_TOKEN")
     click_ctx.session.headers["Authorization"] = f"Bearer {token}"
 
 

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -92,19 +92,11 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     deposit = response.json()
     _log.debug("Created deposit: %s", deposit["links"]["html"])
 
-    # TODO: When updating existing releases, the files API can be used to delete
-    # existing files. GET ``deposit["links"]["files"]`` for a list of ``files`` (names,
-    # checksums, ...), then DELETE ``file["links"]["download"]`` for each ``file`` in
-    # the list.
-
     # Upload the files. We'll use the bucket API rather than the files API as it
     # supports file sizes above 100MB.
     bucket_url = deposit["links"]["bucket"]
     file_name, file_content = _get_file_for_upload(deposition_metadata)
 
-    # TODO: When uploading real files, open them in binary mode and pass the handle to
-    # the data kwarg. For now we'll upload just this one file.
-    # TODO: Do we need to URL-encode the ``file_name`` or does this always work?
     response = click_ctx.session.put(
         f"{bucket_url}/{file_name}",
         data=file_content.encode()

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -13,7 +13,7 @@ import click
 from hermes.model.context import CodeMetaContext
 from hermes.model.path import ContextPath
 
-from .error import DepositionUnauthorizedError
+from hermes.commands.deposit.error import DepositionUnauthorizedError
 
 
 # TODO: It turns out that the schema downloaded here can not be used. Figure out what to

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -5,6 +5,7 @@
 # SPDX-FileContributor: David Pape
 
 from datetime import date
+from getpass import getpass
 
 import click
 import requests
@@ -45,7 +46,21 @@ def map_metadata(click_ctx: click.Context, ctx: CodeMetaContext):
 
 
 def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
-    pass
+    """Make a deposition on an Invenio-based platform.
+
+    This function can:
+
+    - Update the metadata of an existing record
+    - Update the metadata and files of an existing record y creating a new version
+    - Create a new record without any previous versions.
+    """
+
+    invenio_path = ContextPath.parse("deposit.invenio")
+    invenio_ctx = ctx[invenio_path]
+
+    # TODO: Get from environment or parameter
+    token = getpass(f"API token for {invenio_ctx['siteUrl']}: ")
+    click_ctx.session.headers["Authorization"] = f"Bearer {token}"
 
 
 def _request_json(session: requests.Session, url: str) -> dict:

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -62,6 +62,26 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     token = environ.get("HERMES_INVENIO_AUTH_TOKEN")
     click_ctx.session.headers["Authorization"] = f"Bearer {token}"
 
+    # TODO: Get this from config or determine from some value (DOI, ...) in config.
+    existing_record_url = None
+
+    deposit_url = f"{invenio_ctx['siteUrl']}/{invenio_ctx['apiPaths']['depositions']}"
+    if existing_record_url is not None:
+        # TODO: Get by calling new version on existing record
+        deposit_url = None
+        raise NotImplementedError("At the moment, hermes can not create new versions of existing records")
+
+    deposition_metadata = invenio_ctx["depositionMetadata"]
+    response = click_ctx.session.post(deposit_url, json={"metadata": deposition_metadata})
+    response.raise_for_status()
+
+    deposit = response.json()
+    print("New deposit:", deposit["links"]["html"])
+
+    # TODO: Update files if needed
+
+    # TODO: Publish
+
 
 def _request_json(session: requests.Session, url: str) -> dict:
     """Request an URL and return the JSON response as dict."""

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -5,6 +5,7 @@
 # SPDX-FileContributor: David Pape
 
 import json
+import logging
 from datetime import date, datetime
 from os import environ
 
@@ -57,6 +58,8 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     - Create a new record without any previous versions.
     """
 
+    _log = logging.getLogger("cli.deposit.invenio")
+
     invenio_path = ContextPath.parse("deposit.invenio")
     invenio_ctx = ctx[invenio_path]
 
@@ -83,8 +86,7 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     response.raise_for_status()
 
     deposit = response.json()
-    # TODO: Replace print
-    print("New deposit:", deposit["links"]["html"])
+    _log.debug("Created deposit: %s", deposit["links"]["html"])
 
     # ``deposit["metadata"]`` contains a ``prereserve_doi`` field which is a dict like
     # this: ``{'doi': '10.5072/zenodo.1234567', 'recid': 1234567}``. The ``recid`` can
@@ -119,8 +121,7 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     response.raise_for_status()
 
     record = response.json()
-    # TODO: Replace print
-    print("Published record:", record["links"]["record_html"])
+    _log.info("Published record: %s", record["links"]["record_html"])
 
 
 def _codemeta_to_invenio_deposition(metadata: dict) -> dict:

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -6,7 +6,6 @@
 
 import json
 from datetime import date, datetime
-from io import BytesIO
 from os import environ
 
 import click

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -27,7 +27,7 @@ def prepare_deposit(click_ctx: click.Context, ctx: CodeMetaContext):
 
     invenio_ctx = ctx[invenio_path]
     # TODO: Get these values from config with reasonable defaults.
-    recordSchemaUrl = f"{invenio_ctx['siteUrl']}/{invenio_ctx['recordSchemaPath']}"
+    recordSchemaUrl = f"{invenio_ctx['siteUrl']}/{invenio_ctx['schemaPaths']['record']}"
 
     # TODO: cache this download in HERMES cache dir
     # TODO: ensure to use from cache instead of download if not expired (needs config)

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -42,6 +42,7 @@ def map_metadata(ctx: CodeMetaContext):
     metadata_path = ContextPath.parse("deposit.invenio.depositionMetadata")
     ctx.update(metadata_path, deposition_metadata)
 
+
 def deposit(ctx: CodeMetaContext):
     pass
 

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -86,6 +86,13 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     # TODO: Replace print
     print("New deposit:", deposit["links"]["html"])
 
+    # ``deposit["metadata"]`` contains a ``prereserve_doi`` field which is a dict like
+    # this: ``{'doi': '10.5072/zenodo.1234567', 'recid': 1234567}``. The ``recid`` can
+    # be used to construct the URL to the record when published:
+    # ``f"https://sandbox.zenodo.org/record/{recid}"``.
+    # TODO: Use the URL and the DOI to update the data in the repo files before
+    # uploading them.
+
     # TODO: When updating existing releases, the files API can be used to delete
     # existing files. GET ``deposit["links"]["files"]`` for a list of file names with
     # checksums.

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -33,7 +33,9 @@ def prepare_deposit(click_ctx: click.Context, ctx: CodeMetaContext):
 
     # TODO: cache this download in HERMES cache dir
     # TODO: ensure to use from cache instead of download if not expired (needs config)
-    recordSchema = _request_json(click_ctx.session, recordSchemaUrl)
+    response = click_ctx.session.get(recordSchemaUrl)
+    response.raise_for_status()
+    recordSchema = response.json()
     ctx.update(invenio_path["requiredSchema"], recordSchema)
 
 
@@ -106,14 +108,6 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
 
     record = response.json()
     print("Published record:", record["links"]["record_html"])
-
-
-def _request_json(session: requests.Session, url: str) -> dict:
-    """Request an URL and return the JSON response as dict."""
-
-    response = session.get(url)
-    response.raise_for_status()
-    return response.json()
 
 
 def _codemeta_to_invenio_deposition(metadata: dict) -> dict:

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -101,7 +101,12 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     # This can potentially be used to verify the checksum
     # file_resource = response.json()
 
-    # TODO: Publish
+    publish_url = deposit["links"]["publish"]
+    response = click_ctx.session.post(publish_url)
+    response.raise_for_status()
+
+    record = response.json()
+    print("Published record:", record["links"]["record_html"])
 
 
 def _request_json(session: requests.Session, url: str) -> dict:

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -71,7 +71,6 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
         raise DepositionUnauthorizedError("No auth token given for deposition platform")
     click_ctx.session.headers["Authorization"] = f"Bearer {click_ctx.params['auth_token']}"
 
-    # TODO: Get this from config or determine from some value (DOI, ...) in config.
     existing_record_url = None
 
     deposit_url = f"{invenio_ctx['siteUrl']}/{invenio_ctx['apiPaths']['depositions']}"

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -67,9 +67,9 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     invenio_path = ContextPath.parse("deposit.invenio")
     invenio_ctx = ctx[invenio_path]
 
-    if not click_ctx.auth_token:
+    if not click_ctx.params["auth_token"]:
         raise DepositionUnauthorizedError("No auth token given for deposition platform")
-    click_ctx.session.headers["Authorization"] = f"Bearer {click_ctx.auth_token}"
+    click_ctx.session.headers["Authorization"] = f"Bearer {click_ctx.params['auth_token']}"
 
     # TODO: Get this from config or determine from some value (DOI, ...) in config.
     existing_record_url = None

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -72,17 +72,23 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     if existing_record_url is not None:
         # TODO: Get by calling new version on existing record
         deposit_url = None
-        raise NotImplementedError("At the moment, hermes can not create new versions of existing records")
+        raise NotImplementedError(
+            "At the moment, hermes can not create new versions of existing records"
+        )
 
     deposition_metadata = invenio_ctx["depositionMetadata"]
-    response = click_ctx.session.post(deposit_url, json={"metadata": deposition_metadata})
+    response = click_ctx.session.post(
+        deposit_url,
+        json={"metadata": deposition_metadata}
+    )
     response.raise_for_status()
 
     deposit = response.json()
+    # TODO: Replace print
     print("New deposit:", deposit["links"]["html"])
 
     # TODO: When updating existing releases, the files API can be used to delete
-    # existing files. GET ``deposit["links"]["files"]`` for a list of files with
+    # existing files. GET ``deposit["links"]["files"]`` for a list of file names with
     # checksums.
 
     # Upload the files. We'll use the bucket API rather than the files API as it
@@ -107,6 +113,7 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     response.raise_for_status()
 
     record = response.json()
+    # TODO: Replace print
     print("Published record:", record["links"]["record_html"])
 
 

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -9,7 +9,6 @@ from datetime import date, datetime
 from os import environ
 
 import click
-import requests
 
 from hermes.model.context import CodeMetaContext
 from hermes.model.path import ContextPath

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -7,12 +7,13 @@
 import json
 import logging
 from datetime import date, datetime
-from os import environ
 
 import click
 
 from hermes.model.context import CodeMetaContext
 from hermes.model.path import ContextPath
+
+from .error import DepositionUnauthorizedError
 
 
 # TODO: It turns out that the schema downloaded here can not be used. Figure out what to
@@ -63,10 +64,9 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     invenio_path = ContextPath.parse("deposit.invenio")
     invenio_ctx = ctx[invenio_path]
 
-    # TODO: Get from environment or parameter to the deposit command. This can be done
-    # using Click: https://click.palletsprojects.com/en/8.1.x/options/#values-from-environment-variables
-    token = environ["HERMES_INVENIO_AUTH_TOKEN"]
-    click_ctx.session.headers["Authorization"] = f"Bearer {token}"
+    if not click_ctx.auth_token:
+        raise DepositionUnauthorizedError("No auth token given for deposition platform")
+    click_ctx.session.headers["Authorization"] = f"Bearer {click_ctx.auth_token}"
 
     # TODO: Get this from config or determine from some value (DOI, ...) in config.
     existing_record_url = None

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -6,6 +6,7 @@
 
 from datetime import date
 
+import click
 import requests
 
 from hermes.model.context import CodeMetaContext
@@ -14,7 +15,7 @@ from hermes.model.path import ContextPath
 
 # TODO: It turns out that the schema downloaded here can not be used. Figure out what to
 # do with this. Maybe the code can be removed.
-def prepare_deposit(ctx: CodeMetaContext):
+def prepare_deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     """Prepare the Invenio deposit.
 
     In this case, "prepare" means download the record schema that is required
@@ -30,11 +31,11 @@ def prepare_deposit(ctx: CodeMetaContext):
 
     # TODO: cache this download in HERMES cache dir
     # TODO: ensure to use from cache instead of download if not expired (needs config)
-    recordSchema = _request_json(recordSchemaUrl)
+    recordSchema = _request_json(click_ctx.session, recordSchemaUrl)
     ctx.update(invenio_path["requiredSchema"], recordSchema)
 
 
-def map_metadata(ctx: CodeMetaContext):
+def map_metadata(click_ctx: click.Context, ctx: CodeMetaContext):
     """Map the harvested metadata onto the Invenio schema."""
 
     deposition_metadata = _codemeta_to_invenio_deposition(ctx["codemeta"])
@@ -43,15 +44,14 @@ def map_metadata(ctx: CodeMetaContext):
     ctx.update(metadata_path, deposition_metadata)
 
 
-def deposit(ctx: CodeMetaContext):
+def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     pass
 
 
-def _request_json(url: str) -> dict:
+def _request_json(session: requests.Session, url: str) -> dict:
     """Request an URL and return the JSON response as dict."""
 
-    # TODO: Store a requests.Session in a click_ctx in case we need it more frequently?
-    response = requests.get(url)
+    response = session.get(url)
     response.raise_for_status()
     return response.json()
 

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -54,9 +54,12 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
 
     This function can:
 
-    - Update the metadata of an existing record
-    - Update the metadata and files of an existing record y creating a new version
     - Create a new record without any previous versions.
+
+    Functionality to be added in the future:
+
+    - Update the metadata of an existing record
+    - Update the metadata and files of an existing record by creating a new version
     """
 
     _log = logging.getLogger("cli.deposit.invenio")

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -97,8 +97,9 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     # uploading them.
 
     # TODO: When updating existing releases, the files API can be used to delete
-    # existing files. GET ``deposit["links"]["files"]`` for a list of file names with
-    # checksums.
+    # existing files. GET ``deposit["links"]["files"]`` for a list of ``files`` (names,
+    # checksums, ...), then DELETE ``file["links"]["download"]`` for each ``file`` in
+    # the list.
 
     # Upload the files. We'll use the bucket API rather than the files API as it
     # supports file sizes above 100MB.

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -15,6 +15,7 @@ import requests
 
 from hermes.model.context import HermesContext, HermesHarvestContext, CodeMetaContext
 from hermes.model.errors import MergeError
+from hermes.utils import hermes_user_agent
 
 
 @click.group(invoke_without_command=True)
@@ -120,8 +121,7 @@ def deposit(click_ctx: click.Context):
     # TODO: If this is needed in more places, it could be moved one level up.
     click_ctx.session = requests.Session()
     click_ctx.session.headers = {
-        # TODO: Get this from package metadata
-        "User-Agent": "hermes/0.1.0 (https://software-metadata.pub)"
+        "User-Agent": hermes_user_agent,
     }
 
     # local import that can be removed later

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -166,7 +166,16 @@ def deposit():
         metadata_mapping = metadata_mapping_entrypoints[0].load()
         metadata_mapping(ctx)
 
-    # TODO: Deposit
+    # Make deposit: Update metadata, upload files, publish
+    # TODO: Do publish step manually? This would allow users to check the deposition on
+    # the site and decide whether they are happy with it.
+    metadata_mapping_entrypoints = metadata.entry_points(
+        group="hermes.deposit",
+        name=deposition_platform
+    )
+    if metadata_mapping_entrypoints:
+        metadata_mapping = metadata_mapping_entrypoints[0].load()
+        metadata_mapping(ctx)
 
 
 @click.group(invoke_without_command=True)

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -124,9 +124,6 @@ def deposit(click_ctx: click.Context, auth_token):
     click_ctx.session.headers = {
         "User-Agent": hermes_user_agent,
     }
-    # TODO: This seems weird. Is there an option to put it directly into the context
-    # instead of as an argument?
-    click_ctx.auth_token = auth_token
 
     # local import that can be removed later
     from hermes.model.path import ContextPath

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -109,8 +109,9 @@ def process():
 
 
 @click.group(invoke_without_command=True)
+@click.option("--auth-token", envvar="HERMES_DEPOSITION_AUTH_TOKEN")
 @click.pass_context
-def deposit(click_ctx: click.Context):
+def deposit(click_ctx: click.Context, auth_token):
     """
     Deposit processed (and curated) metadata
     """
@@ -123,6 +124,9 @@ def deposit(click_ctx: click.Context):
     click_ctx.session.headers = {
         "User-Agent": hermes_user_agent,
     }
+    # TODO: This seems weird. Is there an option to put it directly into the context
+    # instead of as an argument?
+    click_ctx.auth_token = auth_token
 
     # local import that can be removed later
     from hermes.model.path import ContextPath

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -169,13 +169,13 @@ def deposit():
     # Make deposit: Update metadata, upload files, publish
     # TODO: Do publish step manually? This would allow users to check the deposition on
     # the site and decide whether they are happy with it.
-    metadata_mapping_entrypoints = metadata.entry_points(
+    deposition_entrypoints = metadata.entry_points(
         group="hermes.deposit",
         name=deposition_platform
     )
-    if metadata_mapping_entrypoints:
-        metadata_mapping = metadata_mapping_entrypoints[0].load()
-        metadata_mapping(ctx)
+    if deposition_entrypoints:
+        deposition = deposition_entrypoints[0].load()
+        deposition(ctx)
 
 
 @click.group(invoke_without_command=True)

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -148,10 +148,14 @@ def deposit(click_ctx: click.Context):
 
     # TODO: Remove this
     # There are many Invenio instances. For now, we just use Zenodo as a default.
-    ctx.update(deposit_invenio_path["siteUrl"], "https://zenodo.org")
+    ctx.update(deposit_invenio_path["siteUrl"], "https://sandbox.zenodo.org")
     ctx.update(
-        deposit_invenio_path["recordSchemaPath"],
+        deposit_invenio_path["schemaPaths"]["record"],
         "api/schemas/records/record-v1.0.0.json"
+    )
+    ctx.update(
+        deposit_invenio_path["apiPaths"]["depositions"],
+        "api/deposit/depositions"
     )
 
     # The platform to which we want to deposit the (meta)data

--- a/src/hermes/utils.py
+++ b/src/hermes/utils.py
@@ -7,10 +7,10 @@
 from importlib.metadata import metadata
 
 
-hermes_metadata = metadata("hermes").json
+hermes_metadata = metadata("hermes")
 
 hermes_name = hermes_metadata["name"]
 hermes_version = hermes_metadata["version"]
-hermes_homepage = hermes_metadata["home_page"]
+hermes_homepage = hermes_metadata["home-page"]
 
 hermes_user_agent = f"{hermes_name}/{hermes_version} ({hermes_homepage})"

--- a/src/hermes/utils.py
+++ b/src/hermes/utils.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2023 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# SPDX-FileContributor: David Pape
+
+from importlib.metadata import metadata
+
+
+hermes_metadata = metadata("hermes").json
+
+hermes_name = hermes_metadata["name"]
+hermes_version = hermes_metadata["version"]
+hermes_homepage = hermes_metadata["home_page"]
+
+hermes_user_agent = f"{hermes_name}/{hermes_version} ({hermes_homepage})"

--- a/test/hermes_test/test_cli.py
+++ b/test/hermes_test/test_cli.py
@@ -10,6 +10,7 @@ import click
 from click.testing import CliRunner
 
 from hermes import cli
+from hermes.commands.deposit.error import DepositionUnauthorizedError
 from hermes_test.mocks import mock_command
 
 
@@ -93,7 +94,7 @@ def test_hermes_with_deposit():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', ))
 
-    assert isinstance(result.exception, KeyError)
+    assert isinstance(result.exception, DepositionUnauthorizedError)
 
 
 def test_hermes_with_postprocess():
@@ -114,14 +115,14 @@ def test_hermes_with_deposit_and_postprocess():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', '--postprocess'))
 
-    assert isinstance(result.exception, KeyError)
+    assert isinstance(result.exception, DepositionUnauthorizedError)
 
 
 def test_hermes_with_deposit_and_path():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', '--path', './'))
 
-    assert isinstance(result.exception, KeyError)
+    assert isinstance(result.exception, DepositionUnauthorizedError)
 
 
 def test_hermes_with_path_and_postprocess():
@@ -135,4 +136,4 @@ def test_hermes_with_deposit_and_postprocess_and_path():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', '--postprocess', '--path', './'))
 
-    assert isinstance(result.exception, KeyError)
+    assert isinstance(result.exception, DepositionUnauthorizedError)

--- a/test/hermes_test/test_cli.py
+++ b/test/hermes_test/test_cli.py
@@ -96,7 +96,7 @@ def test_hermes_with_deposit():
     assert not result.exception
 
 
-def test_haggis_with_postprocess():
+def test_hermes_with_postprocess():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--postprocess', ))
 
@@ -110,7 +110,7 @@ def test_hermes_with_path():
     assert not result.exception
 
 
-def test_haggis_with_deposit_and_postprocess():
+def test_hermes_with_deposit_and_postprocess():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', '--postprocess'))
 
@@ -124,14 +124,14 @@ def test_hermes_with_deposit_and_path():
     assert not result.exception
 
 
-def test_haggis_with_path_and_postprocess():
+def test_hermes_with_path_and_postprocess():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--path', './', '--postprocess'))
 
     assert not result.exception
 
 
-def test_haggis_with_deposit_and_postprocess_and_path():
+def test_hermes_with_deposit_and_postprocess_and_path():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', '--postprocess', '--path', './'))
 

--- a/test/hermes_test/test_cli.py
+++ b/test/hermes_test/test_cli.py
@@ -93,7 +93,7 @@ def test_hermes_with_deposit():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', ))
 
-    assert not result.exception
+    assert isinstance(result.exception, KeyError)
 
 
 def test_hermes_with_postprocess():
@@ -114,14 +114,14 @@ def test_hermes_with_deposit_and_postprocess():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', '--postprocess'))
 
-    assert not result.exception
+    assert isinstance(result.exception, KeyError)
 
 
 def test_hermes_with_deposit_and_path():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', '--path', './'))
 
-    assert not result.exception
+    assert isinstance(result.exception, KeyError)
 
 
 def test_hermes_with_path_and_postprocess():
@@ -135,4 +135,4 @@ def test_hermes_with_deposit_and_postprocess_and_path():
     runner = CliRunner()
     result = runner.invoke(cli.main, args=('--deposit', '--postprocess', '--path', './'))
 
-    assert not result.exception
+    assert isinstance(result.exception, KeyError)


### PR DESCRIPTION
This pull request implements the deposit step for Invenio-based platforms which will allow us to make first deposits on Zenodo Sandbox.

It can be tested by setting the environment variable `HERMES_INVENIO_AUTH_TOKEN` to your ["Personal Access Token"](https://sandbox.zenodo.org/account/settings/applications/) for Zenodo Sandbox and running `hermes deposit`, or passing `--auth-token YOUR-TOKEN` to `hermes deposit`. This will create a new publication on Zenodo Sandbox. The publication will contain only a `README.md` file containing some metadata. The README is created from scratch and is not the one from the repo that `hermes deposit` is run in.

**Note:** The access right of the publication is set to "open". This means that everyone with the correct link will see the publication. If you want to hide the content, set `"access_right": "closed"` before running the command.

https://github.com/hermes-hmc/workflow/blob/433a2b34c719a918d1c714453a8c87d92c5ff76f/src/hermes/commands/deposit/invenio.py#L141

Closes #61 

Creating a new version of an existing record will be implemented for #117.