### PR TITLE
Configure depositition through config file

### DIFF
--- a/hermes.toml
+++ b/hermes.toml
@@ -14,3 +14,5 @@ target = "invenio"
 
 [deposit.invenio]
 site_url = "https://sandbox.zenodo.org"
+api_paths = { depositions = "api/deposit/depositions" }
+schema_paths = { record = "api/schemas/records/record-v1.0.0.json" }

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -15,11 +15,11 @@ import requests
 
 from hermes import config
 from hermes.commands.deposit.error import DepositionUnauthorizedError
+from hermes.error import MisconfigurationError
 from hermes.model.context import CodeMetaContext
 from hermes.model.path import ContextPath
 from hermes.utils import hermes_user_agent
 
-_DEFAULT_SITE_URL = "https://sandbox.zenodo.org"
 _DEFAULT_DEPOSITIONS_API_PATH = "api/deposit/depositions"
 _DEFAULT_RECORD_SCHEMA_PATH = "api/schemas/records/record-v1.0.0.json"
 
@@ -37,7 +37,10 @@ def prepare_deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     invenio_path = ContextPath.parse("deposit.invenio")
     invenio_config = config.get("deposit").get("invenio", {})
 
-    site_url = invenio_config.get("site_url", _DEFAULT_SITE_URL)
+    site_url = invenio_config.get("site_url")
+    if site_url is None:
+        raise MisconfigurationError("invenio.site_url is not configured")
+
     record_schema_path = invenio_config.get("schema_paths", {}).get(
         "record", _DEFAULT_RECORD_SCHEMA_PATH
     )

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -99,7 +99,10 @@ def deposit(click_ctx: click.Context, ctx: CodeMetaContext):
 
     existing_record_url = None
 
-    site_url = invenio_config.get("site_url", _DEFAULT_SITE_URL)
+    site_url = invenio_config.get("site_url")
+    if site_url is None:
+        raise MisconfigurationError("deposit.invenio.site_url is not configured")
+
     depositions_api_path = invenio_config.get("api_paths", {}).get(
         "depositions", _DEFAULT_DEPOSITIONS_API_PATH
     )

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -39,14 +39,14 @@ def prepare_deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     record_schema_path = invenio_config.get("schema_paths", {}).get(
         "record", _DEFAULT_RECORD_SCHEMA_PATH
     )
-    recordSchemaUrl = f"{site_url}/{record_schema_path}"
+    record_schema_url = f"{site_url}/{record_schema_path}"
 
     # TODO: cache this download in HERMES cache dir
     # TODO: ensure to use from cache instead of download if not expired (needs config)
-    response = click_ctx.session.get(recordSchemaUrl)
+    response = click_ctx.session.get(record_schema_url)
     response.raise_for_status()
-    recordSchema = response.json()
-    ctx.update(invenio_path["requiredSchema"], recordSchema)
+    record_schema = response.json()
+    ctx.update(invenio_path["requiredSchema"], record_schema)
 
 
 def map_metadata(click_ctx: click.Context, ctx: CodeMetaContext):

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -39,7 +39,7 @@ def prepare_deposit(click_ctx: click.Context, ctx: CodeMetaContext):
 
     site_url = invenio_config.get("site_url")
     if site_url is None:
-        raise MisconfigurationError("invenio.site_url is not configured")
+        raise MisconfigurationError("deposit.invenio.site_url is not configured")
 
     record_schema_path = invenio_config.get("schema_paths", {}).get(
         "record", _DEFAULT_RECORD_SCHEMA_PATH

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -148,13 +148,13 @@ def deposit(click_ctx: click.Context, auth_token, file):
     click.echo("Metadata deposition")
     _log = logging.getLogger("cli.deposit")
 
-    # TODO: Move into context object
-    # TODO: Better name than session?
-    # TODO: If this is needed in more places, it could be moved one level up.
-    click_ctx.session = requests.Session()
-    click_ctx.session.headers = {
+    http_client = requests.Session()
+    http_client.headers = {
         "User-Agent": hermes_user_agent,
     }
+
+    click_ctx.ensure_object(dict)
+    click_ctx.obj["http_client"] = http_client
 
     ctx = CodeMetaContext()
 

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -17,6 +17,7 @@ import requests
 from hermes import config
 from hermes.model.context import HermesContext, HermesHarvestContext, CodeMetaContext
 from hermes.model.errors import MergeError
+from hermes.model.path import ContextPath
 from hermes.utils import hermes_user_agent
 
 
@@ -153,9 +154,6 @@ def deposit(click_ctx: click.Context, auth_token, file):
     click_ctx.session.headers = {
         "User-Agent": hermes_user_agent,
     }
-
-    # local import that can be removed later
-    from hermes.model.path import ContextPath
 
     ctx = CodeMetaContext()
 

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -12,13 +12,11 @@ import logging
 from importlib import metadata
 
 import click
-import requests
 
 from hermes import config
 from hermes.model.context import HermesContext, HermesHarvestContext, CodeMetaContext
 from hermes.model.errors import MergeError
 from hermes.model.path import ContextPath
-from hermes.utils import hermes_user_agent
 
 
 @click.group(invoke_without_command=True)
@@ -147,14 +145,6 @@ def deposit(click_ctx: click.Context, auth_token, file):
     """
     click.echo("Metadata deposition")
     _log = logging.getLogger("cli.deposit")
-
-    http_client = requests.Session()
-    http_client.headers = {
-        "User-Agent": hermes_user_agent,
-    }
-
-    click_ctx.ensure_object(dict)
-    click_ctx.obj["http_client"] = http_client
 
     ctx = CodeMetaContext()
 

--- a/src/hermes/error.py
+++ b/src/hermes/error.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# SPDX-FileContributor: David Pape
+
+class MisconfigurationError(Exception):
+    pass


### PR DESCRIPTION
This pull requests removes a workaround that was introduced to make the deposit.invenio module configurable through the context object, and moves this functionality into the now existing hermes.toml config file.