### PR TITLE
Write valid CodeMeta

### DIFF
--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -313,14 +313,10 @@ def harvest_git(click_ctx: click.Context, ctx: HermesHarvestContext):
     _audit_contributors(git_contributors, logging.getLogger('audit.git'))
 
     ctx.update_from({
-        '@context': [
-            "https://doi.org/10.5063/schema/codemeta-2.0",
-            {'hermes': 'https://software-metadata.pub/ns/hermes/'}
-        ],
-
         '@type': "SoftwareSourceCode",
         'contributor': [contributor.to_codemeta() for contributor in git_contributors._all],
     }, git_branch=git_branch)
+    ctx.add_context(('hermes', 'https://software-metadata.pub/ns/hermes/'))
     ctx.update('hermes:gitBranch', git_branch)
 
     try:

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -315,7 +315,6 @@ def harvest_git(click_ctx: click.Context, ctx: HermesHarvestContext):
     ctx.update('contributor',
                [contributor.to_codemeta() for contributor in git_contributors._all],
                git_branch=git_branch)
-    ctx.add_context(('hermes', 'https://software-metadata.pub/ns/hermes/'))
     ctx.update('hermes:gitBranch', git_branch)
 
     try:

--- a/src/hermes/commands/harvest/git.py
+++ b/src/hermes/commands/harvest/git.py
@@ -312,10 +312,9 @@ def harvest_git(click_ctx: click.Context, ctx: HermesHarvestContext):
 
     _audit_contributors(git_contributors, logging.getLogger('audit.git'))
 
-    ctx.update_from({
-        '@type': "SoftwareSourceCode",
-        'contributor': [contributor.to_codemeta() for contributor in git_contributors._all],
-    }, git_branch=git_branch)
+    ctx.update('contributor',
+               [contributor.to_codemeta() for contributor in git_contributors._all],
+               git_branch=git_branch)
     ctx.add_context(('hermes', 'https://software-metadata.pub/ns/hermes/'))
     ctx.update('hermes:gitBranch', git_branch)
 

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -108,6 +108,7 @@ def process():
             process(ctx, harvest_context)
 
         ctx.merge_from(harvest_context)
+        ctx.merge_contexts_from(harvest_context)
         _log.info('')
     audit_log.info('')
 
@@ -120,6 +121,8 @@ def process():
     tags_path = ctx.get_cache('process', 'tags', create=True)
     with tags_path.open('w') as tags_file:
         json.dump(ctx.tags, tags_file, indent=2)
+
+    ctx.prepare_codemeta()
 
     with open(ctx.get_cache("process", "codemeta", create=True), 'w') as codemeta_file:
         json.dump(ctx._data, codemeta_file, indent=2)

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -119,10 +119,10 @@ def process():
 
     tags_path = ctx.get_cache('process', 'tags', create=True)
     with tags_path.open('w') as tags_file:
-        json.dump(ctx.tags, tags_file, indent='  ')
+        json.dump(ctx.tags, tags_file, indent=2)
 
     with open(ctx.get_cache("process", "codemeta", create=True), 'w') as codemeta_file:
-        json.dump(ctx._data, codemeta_file, indent='  ')
+        json.dump(ctx._data, codemeta_file, indent=2)
 
     logging.shutdown()
 

--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -193,6 +193,13 @@ class HermesHarvestContext(HermesContext):
             self._log.debug("Loading cache from %s...", data_file)
             self._data = json.load(data_file.open('r'))
 
+        contexts_file = self._base.get_cache('harvest', self._ep.name + '_contexts')
+        if contexts_file.is_file():
+            self._log.debug("Loading contexts from %s...", contexts_file)
+            contexts = json.load(contexts_file.open('r'))
+            for context in contexts:
+                self.contexts.add((tuple(context)))
+
     def store_cache(self):
         """
         Store the collected data to the :py:attr:`HermesContext.hermes_dir`.

--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -181,6 +181,7 @@ class HermesHarvestContext(HermesContext):
         self._ep = ep
         self._log = logging.getLogger(f'harvest.{self._ep.name}')
         self.config = config or {}
+        self.contexts = set()
 
     def load_cache(self):
         """
@@ -351,6 +352,15 @@ class HermesHarvestContext(HermesContext):
         Calling this method will lead to further processors not handling the context anymore.
         """
         self._data.clear()
+
+
+    def add_context(self, new_context: tuple) -> None:
+        """
+        Add a new linked data context to the harvest context.
+
+        :param new_context: The new context as tuple (context name, context URI)
+        """
+        self.contexts.add(new_context)
 
 
 class CodeMetaContext(HermesContext):

--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -437,4 +437,6 @@ class CodeMetaContext(HermesContext):
         """
         if self.contexts:
             self.update(ContextPath('@context'), [self._CODEMETA_CONTEXT_URL, dict(self.contexts)])
+        else:
+            self.update(ContextPath('@context'), self._CODEMETA_CONTEXT_URL)
         self.update(ContextPath('@type'), 'SoftwareSourceCode')

--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -156,7 +156,6 @@ class HermesContext:
         if self.hermes_dir.exists():
             shutil.rmtree(self.hermes_dir)
 
-
     def add_context(self, new_context: tuple) -> None:
         """
         Add a new linked data context to the harvest context.
@@ -386,7 +385,6 @@ class CodeMetaContext(HermesContext):
     def __init__(self, project_dir: pathlib.Path | None = None):
         super().__init__(project_dir)
         self.tags = {}
-        self.contexts = set()
 
     def merge_from(self, other: HermesHarvestContext):
         other.get_data(self._data, tags=self.tags)

--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -202,6 +202,11 @@ class HermesHarvestContext(HermesContext):
         self._log.debug("Writing cache to %s...", data_file)
         json.dump(self._data, data_file.open('w'), indent=2)
 
+        if self.contexts:
+            contexts_file = self.get_cache('harvest', self._ep.name + '_contexts', create=True)
+            self._log.debug("Writing contexts to %s...", contexts_file)
+            json.dump(list(self.contexts), contexts_file.open('w'), indent=2)
+
     def __enter__(self):
         self.load_cache()
         return self
@@ -352,7 +357,6 @@ class HermesHarvestContext(HermesContext):
         Calling this method will lead to further processors not handling the context anymore.
         """
         self._data.clear()
-
 
     def add_context(self, new_context: tuple) -> None:
         """

--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -38,6 +38,7 @@ class HermesContext:
 
     default_timestamp = datetime.datetime.now().isoformat(timespec='seconds')
     hermes_cache_name = ".hermes"
+    hermes_lod_context = ("hermes", "https://software-metadata.pub/ns/hermes/")
 
     def __init__(self, project_dir: t.Optional[Path] = None):
         """
@@ -53,6 +54,7 @@ class HermesContext:
         self._caches = {}
         self._data = {}
         self._errors = []
+        self.contexts = {self.hermes_lod_context}
 
     def __getitem__(self, key: ContextPath | str) -> t.Any:
         """
@@ -155,6 +157,15 @@ class HermesContext:
             shutil.rmtree(self.hermes_dir)
 
 
+    def add_context(self, new_context: tuple) -> None:
+        """
+        Add a new linked data context to the harvest context.
+
+        :param new_context: The new context as tuple (context name, context URI)
+        """
+        self.contexts.add(new_context)
+
+
 class HermesHarvestContext(HermesContext):
     """
     A specialized context for use in *harvest* stage.
@@ -181,7 +192,6 @@ class HermesHarvestContext(HermesContext):
         self._ep = ep
         self._log = logging.getLogger(f'harvest.{self._ep.name}')
         self.config = config or {}
-        self.contexts = set()
 
     def load_cache(self):
         """
@@ -364,14 +374,6 @@ class HermesHarvestContext(HermesContext):
         Calling this method will lead to further processors not handling the context anymore.
         """
         self._data.clear()
-
-    def add_context(self, new_context: tuple) -> None:
-        """
-        Add a new linked data context to the harvest context.
-
-        :param new_context: The new context as tuple (context name, context URI)
-        """
-        self.contexts.add(new_context)
 
 
 class CodeMetaContext(HermesContext):

--- a/test/hermes_test/commands/harvest/test_git.py
+++ b/test/hermes_test/commands/harvest/test_git.py
@@ -28,13 +28,6 @@ def harvest_ctx(request: FixtureRequest):
 def codemeta():
     return json.loads("""
 {
-  "@context": [
-    "https://doi.org/10.5063/schema/codemeta-2.0",
-    {
-      "hermes": "https://software-metadata.pub/ns/hermes/"
-    }
-  ],
-  "@type": "SoftwareSourceCode",
   "contributor": [
     {
       "@type": "Person",

--- a/test/hermes_test/model/test_codemeta_context.py
+++ b/test/hermes_test/model/test_codemeta_context.py
@@ -9,11 +9,13 @@ from unittest.mock import Mock
 
 from hermes.model.context import CodeMetaContext, HermesHarvestContext
 
+
 @pytest.fixture
 def mock_ep():
     ep = Mock()
     ep.name = 'mock_name'
     return ep
+
 
 def test_merge_contexts_from(mock_ep):
     _self = CodeMetaContext()

--- a/test/hermes_test/model/test_codemeta_context.py
+++ b/test/hermes_test/model/test_codemeta_context.py
@@ -30,7 +30,9 @@ def _codemeta_context():
 @pytest.fixture
 def _data(_codemeta_context):
     return {
-        '@context': 'https://doi.org/10.5063/schema/codemeta-2.0',
+        '@context': [
+            'https://doi.org/10.5063/schema/codemeta-2.0',
+            {'hermes': 'https://software-metadata.pub/ns/hermes/'}],
         '@type': 'SoftwareSourceCode'
     }
 
@@ -41,17 +43,18 @@ def _data_with_contexts(_codemeta_context):
         '@type': 'SoftwareSourceCode',
         '@context': [
             'https://doi.org/10.5063/schema/codemeta-2.0',
-            {'foo': 'bar'}
+            {'foo': 'bar',
+             'hermes': 'https://software-metadata.pub/ns/hermes/'}
         ]
     }
 
 
 def test_merge_contexts_from(mock_ep, _context, _codemeta_context):
-    assert not _codemeta_context.contexts
+    assert _codemeta_context.contexts == {_codemeta_context.hermes_lod_context}
     other = HermesHarvestContext(None, mock_ep)
     other.contexts.add(_context)
     _codemeta_context.merge_contexts_from(other)
-    assert _codemeta_context.contexts == {_context}
+    assert _codemeta_context.contexts == {_context, _codemeta_context.hermes_lod_context}
 
 
 def test_prepare_codemeta(_codemeta_context, _context, _data):
@@ -62,6 +65,7 @@ def test_prepare_codemeta(_codemeta_context, _context, _data):
 
 def test_prepare_codemeta_with_contexts(_codemeta_context, _context, _data_with_contexts):
     assert not _codemeta_context.keys()
-    _codemeta_context.contexts = {_context}
+    assert _codemeta_context.contexts == {_codemeta_context.hermes_lod_context}
+    _codemeta_context.add_context(_context)
     _codemeta_context.prepare_codemeta()
     assert _codemeta_context.get_data() == _data_with_contexts

--- a/test/hermes_test/model/test_codemeta_context.py
+++ b/test/hermes_test/model/test_codemeta_context.py
@@ -17,11 +17,51 @@ def mock_ep():
     return ep
 
 
-def test_merge_contexts_from(mock_ep):
-    _self = CodeMetaContext()
-    assert not _self.contexts
+@pytest.fixture
+def _context():
+    return 'foo', 'bar'
+
+
+@pytest.fixture
+def _codemeta_context():
+    return CodeMetaContext()
+
+
+@pytest.fixture
+def _data(_codemeta_context):
+    return {
+        '@context': 'https://doi.org/10.5063/schema/codemeta-2.0',
+        '@type': 'SoftwareSourceCode'
+    }
+
+
+@pytest.fixture
+def _data_with_contexts(_codemeta_context):
+    return {
+        '@type': 'SoftwareSourceCode',
+        '@context': [
+            'https://doi.org/10.5063/schema/codemeta-2.0',
+            {'foo': 'bar'}
+        ]
+    }
+
+
+def test_merge_contexts_from(mock_ep, _context, _codemeta_context):
+    assert not _codemeta_context.contexts
     other = HermesHarvestContext(None, mock_ep)
-    context = ('foo', 'bar')
-    other.contexts.add(context)
-    _self.merge_contexts_from(other)
-    assert _self.contexts == {context}
+    other.contexts.add(_context)
+    _codemeta_context.merge_contexts_from(other)
+    assert _codemeta_context.contexts == {_context}
+
+
+def test_prepare_codemeta(_codemeta_context, _context, _data):
+    assert not _codemeta_context.keys()
+    _codemeta_context.prepare_codemeta()
+    assert _codemeta_context.get_data() == _data
+
+
+def test_prepare_codemeta_with_contexts(_codemeta_context, _context, _data_with_contexts):
+    assert not _codemeta_context.keys()
+    _codemeta_context.contexts = {_context}
+    _codemeta_context.prepare_codemeta()
+    assert _codemeta_context.get_data() == _data_with_contexts

--- a/test/hermes_test/model/test_codemeta_context.py
+++ b/test/hermes_test/model/test_codemeta_context.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# SPDX-FileContributor: Stephan Druskat
+
+import pytest
+from unittest.mock import Mock
+
+from hermes.model.context import CodeMetaContext, HermesHarvestContext
+
+@pytest.fixture
+def mock_ep():
+    ep = Mock()
+    ep.name = 'mock_name'
+    return ep
+
+def test_merge_contexts_from(mock_ep):
+    _self = CodeMetaContext()
+    assert not _self.contexts
+    other = HermesHarvestContext(None, mock_ep)
+    context = ('foo', 'bar')
+    other.contexts.add(context)
+    _self.merge_contexts_from(other)
+    assert _self.contexts == {context}


### PR DESCRIPTION
This PR fixes #126.

- Provide API for collecting additional linked data contexts during harvesting
- Merge linked data contexts into CodeMetaContext during processing
- Prepare valid CodeMeta by dumping uncontrolled linked data contexts (e.g., from conversion of CFF to CodeMeta) from data, adding merged contexts, and setting the `@type` property explicitly.