### PR TITLE
Use the correct software license when depositing files to Invenio instance

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,6 +15,7 @@ message: >-
   If you use this software, please cite it using the
   metadata from this file.
 version: "proof-of-concept"
+license: "Apache-2.0"
 abstract: "Proof-of-concept implementation of the HERMES workflow."
 type: software
 authors:

--- a/hermes.toml
+++ b/hermes.toml
@@ -14,5 +14,5 @@ target = "invenio"
 
 [deposit.invenio]
 site_url = "https://sandbox.zenodo.org"
-api_paths = { depositions = "api/deposit/depositions" }
+api_paths = { depositions = "api/deposit/depositions", licenses = "api/licenses" }
 schema_paths = { record = "api/schemas/records/record-v1.0.0.json" }

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -33,7 +33,7 @@ def prepare_deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     """Prepare the Invenio deposit.
 
     In this case, "prepare" means download the record schema that is required by
-    Invenio instances and checking wether we have a valid license identifier that is
+    Invenio instances and checking whether we have a valid license identifier that is
     supported by the instance.
     """
 

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -57,7 +57,7 @@ def prepare_deposit(click_ctx: click.Context, ctx: CodeMetaContext):
     )
     response.raise_for_status()
     record_schema = response.json()
-    ctx.update(invenio_path["record_schema"], record_schema)
+    ctx.update(invenio_path["requiredSchema"], record_schema)
 
     licenses_api_path = invenio_config.get("api_paths", {}).get(
         "licenses", _DEFAULT_LICENSES_API_PATH

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -153,6 +153,10 @@ def deposit(click_ctx: click.Context, auth_token, file):
         _log.error("You must run the process command before deposit")
         return 1
 
+    # Loading the data into the "codemeta" field is a temporary workaround used because
+    # the CodeMetaContext does not provide an update_from method. Eventually we want the
+    # the context to contain `{**data}` rather than `{"codemeta": data}`. Then, for
+    # additional data, the hermes namespace should be used.
     codemeta_path = ContextPath("codemeta")
     with open(codemeta_file) as codemeta_fh:
         ctx.update(codemeta_path, json.load(codemeta_fh))


### PR DESCRIPTION
This pull request fixes the metadata mapping for Invenio-based depositions so that the correct license is used.

The implementation assumes that the license field in the codemeta is a URL whose path ends in a license identifier that can be found on the Invenio instance.

Closes #150 