### PR TITLE
Add ability to store alternative values in the meta-metadata

### DIFF
--- a/src/hermes/commands/process/git.py
+++ b/src/hermes/commands/process/git.py
@@ -62,8 +62,6 @@ def add_branch(ctx: CodeMetaContext, harvest_ctx: HermesHarvestContext):
 
     branch = branch_path.get_from(data)
     audit_log.debug('- %s', branch)
-    if branch_path not in ctx.keys():
-        ctx.update(branch_path, None)
     ctx.update(branch_path, branch, tags=tags)
 
     ctx.tags.update(tags)

--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -341,7 +341,10 @@ class HermesHarvestContext(HermesContext):
                 try:
                     key.update(data, value, tags, **tag)
                     if tags is not None and tag:
-                        tags[str(key)] = tag
+                        if str(key) in tags:
+                            tags[str(key)].update(tag)
+                        else:
+                            tags[str(key)] = tag
                 except errors.MergeError as e:
                     self.error(self._ep, e)
         return data

--- a/src/hermes/model/context.py
+++ b/src/hermes/model/context.py
@@ -372,7 +372,7 @@ class CodeMetaContext(HermesContext):
         if _key._item == '*':
             _item_path, _item, _path = _key.resolve(self._data, query=_value, create=True)
             if tags:
-                _tags = {k.lstrip(str(_key) + '.'): t for k, t in tags.items() if ContextPath.parse(k) in _key}
+                _tags = {k[len(str(_key) + '.'):]: t for k, t in tags.items() if ContextPath.parse(k) in _key}
             else:
                 _tags = {}
             _path._set_item(_item, _path, _value, **_tags)

--- a/src/hermes/model/merge.py
+++ b/src/hermes/model/merge.py
@@ -7,8 +7,6 @@
 from hermes.model.path import ContextPath, set_in_dict
 
 
-
-
 class MergeStrategies:
     def __init__(self):
         self._strategies = []

--- a/src/hermes/model/merge.py
+++ b/src/hermes/model/merge.py
@@ -4,7 +4,9 @@
 
 # SPDX-FileContributor: Michael Meinel
 
-from hermes.model.path import ContextPath
+from hermes.model.path import ContextPath, set_in_dict
+
+
 
 
 class MergeStrategies:
@@ -100,14 +102,7 @@ class CollectionMergeStrategy(MergeStrategy):
                 match target[key]:
                     case dict() as item: item.update(value)
                     case list() as item: item[:] = value
-                    case _:
-                        if target[key] != value:
-                            tag = kwargs.pop('tag', {})
-                            alt = tag.pop('alternatives', [])
-                            alt.append((target[key], tag.copy()))
-                            tag.clear()
-                            tag['alternatives'] = alt
-                        target[key] = value
+                    case _: set_in_dict(target, key, value, kwargs)
 
             case dict(), str() as key:
                 target[key] = value
@@ -138,14 +133,7 @@ class ObjectMergeStrategy(MergeStrategy):
                 match target[key]:
                     case dict() as item: item.update(value)
                     case list() as item: item[:] = value
-                    case _:
-                        if target[key] != value:
-                            tag = kwargs.pop('tag', {})
-                            alt = tag.pop('alternatives', [])
-                            alt.append((target[key], tag.copy()))
-                            tag.clear()
-                            tag['alternatives'] = alt
-                        target[key] = value
+                    case _: set_in_dict(target, key, value, kwargs)
 
             case dict(), str() as key:
                 target[key] = value

--- a/src/hermes/model/merge.py
+++ b/src/hermes/model/merge.py
@@ -100,7 +100,10 @@ class CollectionMergeStrategy(MergeStrategy):
                 match target[key]:
                     case dict() as item: item.update(value)
                     case list() as item: item[:] = value
-                    case _: target[key] = value
+                    case _:
+                        if key in target:
+                            print(target[key], value)
+                        target[key] = value
 
             case dict(), str() as key:
                 target[key] = value
@@ -131,7 +134,14 @@ class ObjectMergeStrategy(MergeStrategy):
                 match target[key]:
                     case dict() as item: item.update(value)
                     case list() as item: item[:] = value
-                    case _: target[key] = value
+                    case _:
+                        if key in target and target[key] != value:
+                            tag = kwargs.pop('tag')
+                            alt = tag.pop('alternatives', [])
+                            alt.append((target[key], tag.copy()))
+                            tag.clear()
+                            tag['alternatives'] = alt
+                        target[key] = value
 
             case dict(), str() as key:
                 target[key] = value

--- a/src/hermes/model/merge.py
+++ b/src/hermes/model/merge.py
@@ -101,8 +101,12 @@ class CollectionMergeStrategy(MergeStrategy):
                     case dict() as item: item.update(value)
                     case list() as item: item[:] = value
                     case _:
-                        if key in target:
-                            print(target[key], value)
+                        if target[key] != value:
+                            tag = kwargs.pop('tag', {})
+                            alt = tag.pop('alternatives', [])
+                            alt.append((target[key], tag.copy()))
+                            tag.clear()
+                            tag['alternatives'] = alt
                         target[key] = value
 
             case dict(), str() as key:
@@ -135,8 +139,8 @@ class ObjectMergeStrategy(MergeStrategy):
                     case dict() as item: item.update(value)
                     case list() as item: item[:] = value
                     case _:
-                        if key in target and target[key] != value:
-                            tag = kwargs.pop('tag')
+                        if target[key] != value:
+                            tag = kwargs.pop('tag', {})
                             alt = tag.pop('alternatives', [])
                             alt.append((target[key], tag.copy()))
                             tag.clear()

--- a/src/hermes/model/path.py
+++ b/src/hermes/model/path.py
@@ -349,9 +349,17 @@ class ContextPath:
         """
         prefix, _target, tail = self.resolve(target, create=True)
         try:
-            prefix.set_item(_target, tail, value, **kwargs)
+            _tag = {}
+            if tags:
+                if str(self) in tags:
+                    _tag = tags[str(self)]
+                else:
+                    tags[str(self)] = _tag
+
+            prefix.set_item(_target, tail, value, tag=_tag, **kwargs)
             if tags is not None and kwargs:
-                tags[str(self)] = kwargs
+                _tag.update(kwargs)
+
         except (KeyError, IndexError, TypeError, ValueError):
             raise errors.MergeError(self, _target, value, **kwargs)
 

--- a/src/hermes/model/path.py
+++ b/src/hermes/model/path.py
@@ -247,7 +247,7 @@ class ContextPath:
                     case list() as item: item[:] = value
                     case _:
                         if target[key] != value:
-                            tag = kwargs.pop('tag')
+                            tag = kwargs.pop('tag', {})
                             alt = tag.pop('alternatives', [])
                             alt.append((target[key], tag.copy()))
                             tag.clear()

--- a/src/hermes/model/path.py
+++ b/src/hermes/model/path.py
@@ -245,7 +245,14 @@ class ContextPath:
                 match target[key]:
                     case dict() as item: item.update(value)
                     case list() as item: item[:] = value
-                    case _: target[key] = value
+                    case _:
+                        if target[key] != value:
+                            tag = kwargs.pop('tag')
+                            alt = tag.pop('alternatives', [])
+                            alt.append((target[key], tag.copy()))
+                            tag.clear()
+                            tag['alternatives'] = alt
+                        target[key] = value
 
             case dict(), str() as key:
                 target[key] = value

--- a/src/hermes/model/path.py
+++ b/src/hermes/model/path.py
@@ -13,6 +13,15 @@ from hermes.model import errors
 
 _log = logging.getLogger('hermes.model.path')
 
+def set_in_dict(target: dict, key: str, value: object, kwargs):
+    if target[key] != value:
+        tag = kwargs.pop('tag', {})
+        alt = tag.pop('alternatives', [])
+        alt.append((target[key], tag.copy()))
+        tag.clear()
+        tag['alternatives'] = alt
+    target[key] = value
+
 
 class ContextPathGrammar:
     """
@@ -245,14 +254,7 @@ class ContextPath:
                 match target[key]:
                     case dict() as item: item.update(value)
                     case list() as item: item[:] = value
-                    case _:
-                        if target[key] != value:
-                            tag = kwargs.pop('tag', {})
-                            alt = tag.pop('alternatives', [])
-                            alt.append((target[key], tag.copy()))
-                            tag.clear()
-                            tag['alternatives'] = alt
-                        target[key] = value
+                    case _: set_in_dict(target, key, value, kwargs)
 
             case dict(), str() as key:
                 target[key] = value

--- a/src/hermes/model/path.py
+++ b/src/hermes/model/path.py
@@ -13,6 +13,7 @@ from hermes.model import errors
 
 _log = logging.getLogger('hermes.model.path')
 
+
 def set_in_dict(target: dict, key: str, value: object, kwargs):
     if target[key] != value:
         tag = kwargs.pop('tag', {})


### PR DESCRIPTION
How to use?

- Run the harvest and process steps
- Copy the `.hermes/process/codemeta.json` to your project dir (and slightly modify it ... to trigger new behaviour)
- Enable `codemeta` as harvester (in `hermes.toml`)
- Run harvest and process step again
- Have a look at the additional metadata `alternatives` in `hermes/process/tags.json`
