### PR TITLE
Add curation step to the workflow

### DIFF
--- a/src/hermes/cli.py
+++ b/src/hermes/cli.py
@@ -143,6 +143,7 @@ class WorkflowCommand(click.Group):
     "--config", default=pathlib.Path('hermes.toml'),
     help="Configuration file in TOML format", type=pathlib.Path
 )
+@click.option("--curate", is_flag=True, default=False)
 @click.option("--deposit", is_flag=True, default=False)
 @click.option("--postprocess", is_flag=True, default=False)
 @click.option("--clean", is_flag=True, default=False)
@@ -161,5 +162,6 @@ def main(ctx: click.Context, *args, **kwargs) -> None:
 main.add_command(workflow.clean)
 main.add_command(workflow.harvest)
 main.add_command(workflow.process)
+main.add_command(workflow.curate)
 main.add_command(workflow.deposit)
 main.add_command(workflow.postprocess)

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -9,6 +9,8 @@
 
 import json
 import logging
+import os
+import shutil
 from importlib import metadata
 
 import click
@@ -127,6 +129,13 @@ def process():
         json.dump(ctx._data, codemeta_file, indent=2)
 
     logging.shutdown()
+
+
+@click.group(invoke_without_command=True)
+def curate():
+    ctx = CodeMetaContext()
+    os.makedirs(ctx.hermes_dir / 'curate', exist_ok=True)
+    shutil.copy(ctx.hermes_dir / 'process' / 'codemeta.json', ctx.hermes_dir / 'curate' / 'codemeta.json')
 
 
 @click.group(invoke_without_command=True)

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -151,9 +151,9 @@ def deposit(click_ctx: click.Context, auth_token, file):
 
     ctx = CodeMetaContext()
 
-    codemeta_file = ctx.get_cache("process", "codemeta")
+    codemeta_file = ctx.get_cache("curate", "codemeta")
     if not codemeta_file.exists():
-        _log.error("You must run the process command before deposit")
+        _log.error("You must run the 'curate' command before deposit")
         return 1
 
     # Loading the data into the "codemeta" field is a temporary workaround used because


### PR DESCRIPTION
A minimal, very shaky 'curation' step was implemented that simply copies over the codemeta.json without the tags.