### PR TITLE
Improve log file locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@ dist/
 
 # HERMES workflow specifics
 .hermes
-hermes-audit.md
-hermes.log
-quickfix.sh

--- a/src/hermes/cli.py
+++ b/src/hermes/cli.py
@@ -85,7 +85,7 @@ class WorkflowCommand(click.Group):
         """
 
         # Get the user provided working dir from the --path option or default to current working directory.
-        working_path = ctx.params.get('path', pathlib.Path.cwd()).absolute()
+        working_path = ctx.params.get('path').absolute()
 
         configure(ctx.params.get('config').absolute(), working_path)
         init_logging()

--- a/src/hermes/cli.py
+++ b/src/hermes/cli.py
@@ -84,13 +84,16 @@ class WorkflowCommand(click.Group):
         :param ctx: Context for the command.
         """
 
-        configure(ctx.params.get('config').absolute())
+        # Get the user provided working dir from the --path option or default to current working directory.
+        working_path = ctx.params.get('path', pathlib.Path.cwd()).absolute()
+
+        configure(ctx.params.get('config').absolute(), working_path)
         init_logging()
         log_header(None)
 
         audit_log = logging.getLogger('audit')
         audit_log.info("# Running Hermes")
-        audit_log.info("Running Hermes command line in: %s", ctx.params.get('path', pathlib.Path.cwd()).absolute())
+        audit_log.info("Running Hermes command line in: %s", working_path)
         audit_log.debug("")
         audit_log.debug("Invoked `%s` with", ctx.invoked_subcommand or self.name)
         audit_log.debug("")

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -71,8 +71,10 @@ def configure(config_path: pathlib.Path, working_path: pathlib.Path):
         return
 
     # Load sane default paths for log files before potentially overwritting via configuration
-    _config['logging']['handlers']['logfile']['filename'] = working_path / HermesContext.hermes_cache_name / "hermes.log"
-    _config['logging']['handlers']['auditfile']['filename'] = working_path / HermesContext.hermes_cache_name / "audit.log"
+    _config['logging']['handlers']['logfile']['filename'] = \
+        working_path / HermesContext.hermes_cache_name / "hermes.log"
+    _config['logging']['handlers']['auditfile']['filename'] = \
+        working_path / HermesContext.hermes_cache_name / "audit.log"
 
     # Load configuration if not present
     try:

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -130,8 +130,8 @@ def init_logging():
         return
 
     # Make sure the directories to hold the log files exists (or else create)
-    _config['logging']['handlers']['logfile']['filename'].parent.mkdir(exist_ok=True, parents=True)
-    _config['logging']['handlers']['auditfile']['filename'].parent.mkdir(exist_ok=True, parents=True)
+    pathlib.Path(_config['logging']['handlers']['logfile']['filename']).parent.mkdir(exist_ok=True, parents=True)
+    pathlib.Path(_config['logging']['handlers']['auditfile']['filename']).parent.mkdir(exist_ok=True, parents=True)
 
     # Inintialize logging system
     import logging.config

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -10,6 +10,8 @@ import sys
 
 import toml
 
+from hermes.model.context import HermesContext
+
 # This is the default logging configuration, required to see log output at all.
 #  - Maybe it could possibly somehow be a somewhat good idea to move this into an own module ... later perhaps
 _logging_config = {
@@ -33,14 +35,14 @@ _logging_config = {
             'class': "logging.FileHandler",
             'formatter': "logfile",
             'level': "DEBUG",
-            'filename': "hermes.log",
+            'filename': "./.hermes/hermes.log",
         },
 
         'auditfile': {
             'class': "logging.FileHandler",
             'formatter': "plain",
             'level': "DEBUG",
-            'filename': "hermes-audit.md",
+            'filename': "./.hermes/audit.log",
             'mode': "w",
         },
     },
@@ -59,7 +61,7 @@ _config = {
 }
 
 
-def configure(config_path: pathlib.Path):
+def configure(config_path: pathlib.Path, working_path: pathlib.Path):
     """
     Load the configuration from the given path as global hermes configuration.
 
@@ -67,6 +69,10 @@ def configure(config_path: pathlib.Path):
     """
     if 'hermes' in _config and _config['hermes']:
         return
+
+    # Load sane default paths for log files before potentially overwritting via configuration
+    _config['logging']['handlers']['logfile']['filename'] = working_path / HermesContext.hermes_cache_name / "hermes.log"
+    _config['logging']['handlers']['auditfile']['filename'] = working_path / HermesContext.hermes_cache_name / "audit.log"
 
     # Load configuration if not present
     try:
@@ -120,6 +126,10 @@ _loggers = {}
 def init_logging():
     if _loggers:
         return
+
+    # Make sure the directories to hold the log files exists (or else create)
+    _config['logging']['handlers']['logfile']['filename'].parent.mkdir(exist_ok=True, parents=True)
+    _config['logging']['handlers']['auditfile']['filename'].parent.mkdir(exist_ok=True, parents=True)
 
     # Inintialize logging system
     import logging.config

--- a/test/hermes_test/test_cli.py
+++ b/test/hermes_test/test_cli.py
@@ -47,6 +47,7 @@ def test_workflow_invoke():
     wf.add_command(eggs_cmd)
 
     ctx = click.Context(wf)
+    ctx.params['path'] = pathlib.Path.cwd()
     ctx.params['config'] = pathlib.Path.cwd() / 'hermes.toml'
     wf.invoke(ctx)
 
@@ -65,12 +66,13 @@ def test_workflow_invoke_with_cb():
     wf.result_callback()(cb_mock)
 
     ctx = click.Context(wf)
+    ctx.params['path'] = pathlib.Path.cwd()
     ctx.params['config'] = pathlib.Path.cwd() / 'hermes.toml'
     wf.invoke(ctx)
 
     spam.assert_called_once()
     eggs.assert_called_once()
-    cb_mock.assert_called_with(["spam", "eggs"], config=ctx.params['config'])
+    cb_mock.assert_called_with(["spam", "eggs"], config=ctx.params['config'], path=ctx.params['path'])
 
 
 def test_hermes_full():


### PR DESCRIPTION
Relates to #138

1. Make sure the parent directories of the configured log file locations exist (so we can use them) - or else create them
2. Move default location of hermes log into cache dir