### PR TITLE
Add Druskat + Meinel to mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -13,3 +13,5 @@
 # Real Name <email@address> Name, Real
 Jeffrey Kelling <j.kelling@hzdr.de> jkelling
 David Pape <d.pape@hzdr.de> David
+Stephan Druskat <stephan.druskat@dlr.de> Druskat, Stephan
+Michael Meinel <michael.meinel@dlr.de> Meinel, Michael


### PR DESCRIPTION
Shortlog before:

```
   222  Stephan Druskat
   114  Oliver Bertuch
   111  Michael Meinel
   103  David Pape
    43  Meinel, Michael
    33  Druskat, Stephan
    24  Jeffrey Kelling
     1  Oliver Knodel
```

and after:

```
   255  Stephan Druskat
   154  Michael Meinel
   114  Oliver Bertuch
   104  David Pape
    24  Jeffrey Kelling
     1  Oliver Knodel
```