### PR TITLE
Update tutorial to not include mapping key in hermes.toml

### DIFF
--- a/docs/source/tutorials/automated-publication-with-ci.md
+++ b/docs/source/tutorials/automated-publication-with-ci.md
@@ -72,7 +72,6 @@ Configure HERMES to:
 from = [ "git", "cff" ]
 
 [deposit]
-mapping = "invenio"
 target = "invenio"
 
 [deposit.invenio]


### PR DESCRIPTION
This is no longer necessary and in fact doesn't do anything (the `map` key needs to be used for this endpoint).