### PR TITLE
Fix logging-related crash in `hermes clean`

### DIFF
--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -291,7 +291,7 @@ def clean():
     """
     Remove cached data.
     """
-    audit_log = logging.getLogger('audit')
+    audit_log = logging.getLogger('cli')
     audit_log.info("# Cleanup")
 
     # Create Hermes context (i.e., all collected metadata for all stages...)

--- a/src/hermes/commands/workflow.py
+++ b/src/hermes/commands/workflow.py
@@ -293,6 +293,8 @@ def clean():
     """
     audit_log = logging.getLogger('cli')
     audit_log.info("# Cleanup")
+    # shut down logging so that .hermes/ can safely be removed
+    logging.shutdown()
 
     # Create Hermes context (i.e., all collected metadata for all stages...)
     ctx = HermesContext()


### PR DESCRIPTION
Closes #225 

The problem is solved by shutting down logging facilities before the `.hermes` directory is removed. For good measure, `hermes clean` only logs to the terminal as it doesn't make sense to write to files which are immediately removed.