### PR TITLE
Further fixes to InvenioRDM to work properly with the tutorial (... and at all)

### DIFF
--- a/hermes.toml
+++ b/hermes.toml
@@ -9,7 +9,6 @@ from = [ "cff", "git" ]
 validate = false
 
 [deposit]
-mapping = "invenio_rdm"
 target = "invenio_rdm"
 
 [deposit.invenio_rdm]

--- a/src/hermes/commands/deposit/invenio_rdm.py
+++ b/src/hermes/commands/deposit/invenio_rdm.py
@@ -134,7 +134,7 @@ def create_initial_version(click_ctx: click.Context, ctx: CodeMetaContext):
     )
 
     if not response.ok:
-        print(response.text)
+        _log.error("Webserver response: \n%s", response.text)
         raise RuntimeError(f"Could not create initial deposit {deposit_url!r}")
 
     deposit = response.json()

--- a/src/hermes/commands/deposit/invenio_rdm.py
+++ b/src/hermes/commands/deposit/invenio_rdm.py
@@ -536,9 +536,16 @@ def _get_license_identifier(ctx: CodeMetaContext, license_api_url: str):
 
     An API endpoint (usually ``/api/vocabularies/licenses``) can be used to check whether a given
     license is supported by the Invenio instance. This function tries to retrieve the
-    license by the identifier at the end of the license URL path. If this identifier
-    does not exist on the Invenio instance, a :class:`RuntimeError` is raised. If no
-    license is given in the CodeMeta, ``None`` is returned.
+    license by lower-casing the identifier at the end of the license URL path. If this identifier
+    does not exist on the Invenio instance, all available licenses are fetched and the URL is sought
+    for in the results. However, this might again not lead to success (as Invenio still provides
+    the obsolete https://opensource.org URLs) but harvesters might provide the SPDX style URLs.
+    Hence, the license URL is checked whether it is pointing to https://spdx.org/licenses/ and if
+    this is the case, the license record from SPDX is fetched and all `crossRef` URLs that are flagged
+    `isValid` are again sought for in the full set of licenses. Only if this still fails,
+    a :class:`RuntimeError` is raised.
+
+    If no license is given in the CodeMeta, ``None`` is returned.
     """
 
     license_url = ctx["codemeta"].get("license")

--- a/src/hermes/model/path.py
+++ b/src/hermes/model/path.py
@@ -29,7 +29,7 @@ class ContextPathGrammar:
     The pyparsing grammar for ContextGrammar paths.
     """
 
-    key = pp.Word('@:' + pp.alphas)
+    key = pp.Word('@:_' + pp.alphas)
     index = pp.Word(pp.nums).set_parse_action(lambda tok: [int(tok[0])]) | pp.Char('*')
     field = key + (pp.Suppress('[') + index + pp.Suppress(']'))[...]
     path = field + (pp.Suppress('.') + field)[...]


### PR DESCRIPTION
Note that (for ... reasons) this also includes #228.

This is due to the hotfix/invenio-rdm branch is used for a concrete project already but. But for this to work, the change in the post-processing (which is part of the feature/227-adapt-tutorial-for-inveniordm branch) needed to be included.

Hence, I closed the #228 again.

Fixes #227
